### PR TITLE
Ошибка в контракте AutosignReceiptsResult.

### DIFF
--- a/proto/CloudSign.proto
+++ b/proto/CloudSign.proto
@@ -20,6 +20,6 @@ message CloudSignConfirmResult {
 }
 
 message AutosignReceiptsResult {
-    required string NextBatchKey = 1;
-    required int32 SignedReceiptsCount = 2;
+    required int32 SignedReceiptsCount = 1;
+    optional string NextBatchKey = 2;
 }


### PR DESCRIPTION
Фикс по открытому багу: https://github.com/diadoc/diadocsdk-java/issues/61

Вручную попробовал выполнить автоматическое подписание с использованием REST API, получил бинарный ответ для метода http://api-docs.diadoc.ru/ru/latest/http/AutoSignReceiptsResult.html

Затем пытался из него восстановить данные и смог только в таком виде контракта. Т.е. нужно поменять порядок полей и одно из них сделать необязательным.