### PR TITLE
get algorithm name from privateKey

### DIFF
--- a/src/main/java/Diadoc/Api/DiadocApi.java
+++ b/src/main/java/Diadoc/Api/DiadocApi.java
@@ -339,11 +339,11 @@ public class DiadocApi {
         decodeAsn1Bytes(encrKey, recipientInfo.encryptedKey.value);
         byte[] encodedPub = encodeAsn1(encrKey.transportParameters.ephemeralPublicKey);
         X509EncodedKeySpec pspec = new X509EncodedKeySpec(encodedPub);
-        KeyFactory kf = KeyFactory.getInstance(JCP.GOST_DH_NAME);
-        PublicKey senderPublic = kf.generatePublic(pspec);
-        KeyAgreement responderKeyAgree = KeyAgreement.getInstance(JCP.GOST_DH_NAME);
-        byte[] sv = encrKey.transportParameters.ukm.value;
         PrivateKey privateKey = CertificateHelper.getPrivateKey(currentCert, null);
+        KeyFactory kf = KeyFactory.getInstance(privateKey.getAlgorithm());
+        PublicKey senderPublic = kf.generatePublic(pspec);
+        KeyAgreement responderKeyAgree = KeyAgreement.getInstance(privateKey.getAlgorithm());
+        byte[] sv = encrKey.transportParameters.ukm.value;
         responderKeyAgree.init(privateKey, new IvParameterSpec(sv));
         responderKeyAgree.doPhase(senderPublic, true);
         Key responderSecret = responderKeyAgree.generateSecret(CryptoProvider.GOST_CIPHER_NAME);

--- a/src/main/java/Diadoc/Api/DiadocApi.java
+++ b/src/main/java/Diadoc/Api/DiadocApi.java
@@ -37,7 +37,7 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.params.*;
 import ru.CryptoPro.Crypto.CryptoProvider;
-import ru.CryptoPro.Crypto.spec.GostCipherSpec;
+import ru.CryptoPro.JCP.spec.GostCipherSpec;
 import ru.CryptoPro.JCP.ASN.CryptographicMessageSyntax.ContentInfo;
 import ru.CryptoPro.JCP.ASN.CryptographicMessageSyntax.EnvelopedData;
 import ru.CryptoPro.JCP.ASN.CryptographicMessageSyntax.KeyTransRecipientInfo;


### PR DESCRIPTION
Данное изменение позволяет получать алгоритм из закрытого ключа, что дает возможность использовать так же JCP версии 2.