### PR TITLE
Force using UTF-8 for error messages

### DIFF
--- a/src/main/java/Diadoc/Api/httpClient/DiadocHttpClient.java
+++ b/src/main/java/Diadoc/Api/httpClient/DiadocHttpClient.java
@@ -30,6 +30,7 @@ import javax.mail.internet.ContentDisposition;
 import javax.mail.internet.ParseException;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -112,7 +113,7 @@ public class DiadocHttpClient {
         if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
             throw new HttpResponseException(
                     response.getStatusLine().getStatusCode(),
-                    new String(IOUtils.toByteArray(response.getEntity().getContent())));
+                    new String(IOUtils.toByteArray(response.getEntity().getContent()), StandardCharsets.UTF_8));
         }
         return IOUtils.toByteArray(response.getEntity().getContent());
     }
@@ -121,7 +122,7 @@ public class DiadocHttpClient {
         if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
             return DiadocResponseInfo.fail(
                     response.getStatusLine().getStatusCode(),
-                    new String(IOUtils.toByteArray(response.getEntity().getContent())),
+                    new String(IOUtils.toByteArray(response.getEntity().getContent()), StandardCharsets.UTF_8),
                     tryGetRetryAfter(response));
         }
         return DiadocResponseInfo.success(IOUtils.toByteArray(response.getEntity().getContent()), response.getStatusLine().getStatusCode());


### PR DESCRIPTION
На системах с кодировкой, отличной от UTF-8 (напр. Windows), приходится использовать параметр -Dfile.encoding=UTF8, чтобы текст на кириллице отображался правильно.\
Чтобы избежать этого, принудительно используем UTF-8 для интерпретации ошибок из API 