### PR TITLE
Fix JCP dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,29 +66,34 @@
             <groupId>ru.CryptoPro</groupId>
             <artifactId>JCP</artifactId>
             <version>2.0.40450-A</version>
+            <scope>provided</scope>
         </dependency>
         <!-- local -->
         <dependency>
             <groupId>com.objsys.asn1j</groupId>
             <artifactId>asn1rt</artifactId>
             <version>2.0.40450-A</version>
+            <scope>provided</scope>
         </dependency>
         <!-- local -->
         <dependency>
             <groupId>ru.CryptoPro</groupId>
             <artifactId>ASN1P</artifactId>
             <version>2.0.40450-A</version>
+            <scope>provided</scope>
         </dependency>
         <!-- local -->
         <dependency>
             <groupId>ru.CryptoPro</groupId>
             <artifactId>JCryptoP</artifactId>
             <version>2.0.40450-A</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>16.0.1</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
ru.CryptoPro.JCP not available in public repo, and 90% API work without JCP.
Приходится с каждой версией править jar