### PR TITLE
Методы для аутенфикации при отсутствии прямого доступа к сертификату

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ fabric.properties
 
 #jcp
 jcp-*
+/replay_pid85356.log

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>ru.kontur.diadoc</groupId>
     <artifactId>diadocsdk</artifactId>
-    <version>3.20.0-dev.5296.26860</version>
+    <version>3.20.0-dev.5296.26860_spimex</version>
 
     <packaging>jar</packaging>
 


### PR DESCRIPTION
добавлены методы, которые принимают DER сериализованный сертификат для случаев, когда сертификат напрямую недоступен приложению и приложение получает его в качества входного параметра

authenticate(X509Certificate currentCert, boolean autoConfirm) имеет возвращаемое значение, чтобы можно было продолжить работу, при autoConfirm = false