### PR TITLE
DDCORE-9224 Добавить универсального подписанта (SignerContent) 

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -11,7 +11,14 @@ var protocLink = "https://github.com/google/protobuf/releases/download/v2.6.1/pr
 var protocArchive = buildDir.CombineWithFilePath("protoc-2.6.1-win32.zip");
 var protocBinDir = buildDir.Combine("protoc");
 var protocExe = protocBinDir.CombineWithFilePath("protoc.exe");
-var mvnTool = new [] { "mvn.cmd", "mvn.exe", "mvn" }.Select(x => Context.Tools.Resolve(x)).Where(x => x != null).FirstOrDefault();
+
+var descriptorSourceLink = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v2.6.1.zip";
+var descriptorArchive = buildDir.CombineWithFilePath("protobuf-v2.6.1.zip");
+var descriptorSourceDir = buildDir.Combine("protobuf-src");
+var includeDir = protocBinDir.Combine("include");
+var googleProtobufDir = includeDir.Combine("google").Combine("protobuf");
+
+var mvnTool = new[] { "mvn.cmd", "mvn.exe", "mvn" }.Select(x => Context.Tools.Resolve(x)).Where(x => x != null).FirstOrDefault();
 
 //////////////////////////////////////////////////////////////////////
 // TASKS
@@ -40,12 +47,62 @@ Task("ExtractProtobuf")
 		Unzip(protocArchive, protocBinDir);
 	});
 
+Task("DownloadDescriptorFiles")
+    .WithCriteria(() => !DirectoryExists(googleProtobufDir))
+    .Does(() =>
+    {
+        CreateDirectory(descriptorArchive.GetDirectory());
+        DownloadFile(descriptorSourceLink, descriptorArchive);
+    });
+
+Task("ExtractDescriptorFiles")
+    .WithCriteria(!DirectoryExists(googleProtobufDir)) // Проверяем, создана ли целевая директория
+    .IsDependentOn("DownloadDescriptorFiles")
+    .Does(() =>
+    {
+        if (!DirectoryExists(descriptorSourceDir))
+        {
+            Information("Extracting descriptor archive to: {0}", descriptorSourceDir.FullPath);
+            Unzip(descriptorArchive, descriptorSourceDir);
+        }
+        else
+        {
+            Information("Descriptor source directory already exists: {0}", descriptorSourceDir.FullPath);
+        }
+
+        // Проверяем, что директория с исходниками .proto существует
+        var protoSourceDir = descriptorSourceDir.Combine("protobuf-2.6.1/src/google/protobuf");
+        if (!DirectoryExists(protoSourceDir))
+            throw new Exception($"Source directory for descriptor.proto not found: {protoSourceDir.FullPath}");
+
+        // Создаём директорию include/google/protobuf, если её нет
+        CreateDirectory(googleProtobufDir);
+
+        // Копируем только файлы protobuf
+        foreach (var file in GetFiles(protoSourceDir.FullPath + "/*.proto"))
+        {
+            var destinationFile = googleProtobufDir.CombineWithFilePath(file.GetFilename());
+
+            // Удаляем файл, если он уже существует
+            if (FileExists(destinationFile))
+            {
+                Information("Overwriting existing file: {0}", destinationFile.FullPath);
+                DeleteFile(destinationFile);
+            }
+
+            CopyFile(file, destinationFile);
+        }
+
+        Information("Descriptor files extracted to: {0}", googleProtobufDir.FullPath);
+    });
+
 Task("GenerateProtoFiles")
-	.IsDependentOn("ExtractProtobuf")
-	.Does(() =>
-	{
-		var sourceProtoDir = new DirectoryPath("./proto/").MakeAbsolute(Context.Environment);
-		var destinationProtoDir = new DirectoryPath("./src/main/java/").MakeAbsolute(Context.Environment);
+    .IsDependentOn("ExtractProtobuf")
+    .IsDependentOn("ExtractDescriptorFiles")
+    .Does(() =>
+    {
+        var sourceProtoDir = new DirectoryPath("./proto/").MakeAbsolute(Context.Environment);
+        var destinationProtoDir = new DirectoryPath("./src/main/java/").MakeAbsolute(Context.Environment);
 
 		var protoFiles = GetFiles("./proto/**/*.proto");
 		var modifiedProtoDir = buildDir.Combine("modified_proto");
@@ -147,10 +204,11 @@ public void CompileProtoFiles(IEnumerable<FilePath> files, DirectoryPath sourceP
 {
 	CreateDirectory(destinationProtoDir);
 
-	var protocArguments = new ProcessSettings()
-		.WithArguments(args => args
-			.Append("-I=" + sourceProtoDir.FullPath)
-			.Append("--java_out=" + destinationProtoDir.FullPath));
+    var protocArguments = new ProcessSettings()
+        .WithArguments(args => args
+            .Append("-I=" + sourceProtoDir.FullPath)
+            .Append("-I=" + includeDir.FullPath)
+            .Append("--java_out=" + destinationProtoDir.FullPath));
 
 	foreach (var file in files)
 	{
@@ -222,7 +280,7 @@ public string GetSemanticVersionV2(string clearVersion)
 		{
 			return clearVersion;
 		}
-		
+
 		var buildNumber = workflow.RunNumber;
 		return $"{clearVersion}-CI{buildNumber}";
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,6 @@
     <artifactId>diadocsdk</artifactId>
     <version>3.24.1</version>
 
-
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,8 @@
 
     <groupId>ru.kontur.diadoc</groupId>
     <artifactId>diadocsdk</artifactId>
-    <version>3.24.0</version>
+    <version>3.24.1</version>
+
 
     <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
     <artifactId>diadocsdk</artifactId>
     <version>3.24.1</version>
 
+
     <packaging>jar</packaging>
 
     <properties>

--- a/proto/CloudSign.proto
+++ b/proto/CloudSign.proto
@@ -3,23 +3,23 @@ import "Content_v2.proto";
 package Diadoc.Api.Proto;
 
 message CloudSignRequest {
-	repeated CloudSignFile Files = 1; 
+	repeated CloudSignFile Files = 1 [deprecated = true];
 }
 
 message CloudSignFile {
-	optional Content_v2 Content = 1;
-	optional string FileName = 2;
+	optional Content_v2 Content = 1 [deprecated = true];
+	optional string FileName = 2 [deprecated = true];
 }
 
 message CloudSignResult {
-	optional string Token = 1;
+	optional string Token = 1 [deprecated = true];
 }
 
 message CloudSignConfirmResult {
-	repeated Content_v2 Signatures = 1;
+	repeated Content_v2 Signatures = 1 [deprecated = true];
 }
 
 message AutosignReceiptsResult {
-	required int64 SignedReceiptsCount = 1;
-	required string NextBatchKey = 2;
+	required int64 SignedReceiptsCount = 1 [deprecated = true];
+	required string NextBatchKey = 2 [deprecated = true];
 }

--- a/proto/CloudSign.proto
+++ b/proto/CloudSign.proto
@@ -1,13 +1,6 @@
 import "Content_v2.proto";
-import "google/protobuf/descriptor.proto";
 
 package Diadoc.Api.Proto;
-
-extend google.protobuf.FileOptions {
-	optional bool file_deprecated = 50001;
-}
-
-option (file_deprecated) = true;
 
 message CloudSignRequest {
 	repeated CloudSignFile Files = 1 [deprecated = true];

--- a/proto/CloudSign.proto
+++ b/proto/CloudSign.proto
@@ -1,25 +1,37 @@
 import "Content_v2.proto";
+import "google/protobuf/descriptor.proto";
 
 package Diadoc.Api.Proto;
 
+extend google.protobuf.FileOptions {
+	optional bool file_deprecated = 50001;
+}
+
+option (file_deprecated) = true;
+
 message CloudSignRequest {
 	repeated CloudSignFile Files = 1 [deprecated = true];
+	option deprecated = true;
 }
 
 message CloudSignFile {
 	optional Content_v2 Content = 1 [deprecated = true];
 	optional string FileName = 2 [deprecated = true];
+	optional bool deprecated = 3 [default = true];
 }
 
 message CloudSignResult {
 	optional string Token = 1 [deprecated = true];
+	option deprecated = true;
 }
 
 message CloudSignConfirmResult {
 	repeated Content_v2 Signatures = 1 [deprecated = true];
+	option deprecated = true;
 }
 
 message AutosignReceiptsResult {
 	required int64 SignedReceiptsCount = 1 [deprecated = true];
 	required string NextBatchKey = 2 [deprecated = true];
+	option deprecated = true;
 }

--- a/proto/CloudSign.proto
+++ b/proto/CloudSign.proto
@@ -4,27 +4,22 @@ package Diadoc.Api.Proto;
 
 message CloudSignRequest {
 	repeated CloudSignFile Files = 1 [deprecated = true];
-	option deprecated = true;
 }
 
 message CloudSignFile {
 	optional Content_v2 Content = 1 [deprecated = true];
 	optional string FileName = 2 [deprecated = true];
-	optional bool deprecated = 3 [default = true];
 }
 
 message CloudSignResult {
 	optional string Token = 1 [deprecated = true];
-	option deprecated = true;
 }
 
 message CloudSignConfirmResult {
 	repeated Content_v2 Signatures = 1 [deprecated = true];
-	option deprecated = true;
 }
 
 message AutosignReceiptsResult {
 	required int64 SignedReceiptsCount = 1 [deprecated = true];
 	required string NextBatchKey = 2 [deprecated = true];
-	option deprecated = true;
 }

--- a/proto/Events/DiadocMessage-PostApi.proto
+++ b/proto/Events/DiadocMessage-PostApi.proto
@@ -446,6 +446,7 @@ message DraftDocumentToPatch {
 	optional string ToBoxId = 2;
 	optional Invoicing.Signer Signer = 3;
 	repeated Invoicing.Signers.ExtendedSigner ExtendedSigner = 4;
+	optional bytes SignerContent = 5;
 }
 
 message ContentToPatch {
@@ -456,12 +457,14 @@ message ContentToPatch {
 	optional string ToBoxId = 5;
 	optional Invoicing.Signer Signer = 6;
 	repeated Invoicing.Signers.ExtendedSigner ExtendedSigner = 7;
+	optional bytes SignerContent = 8;
 }
 
 message DocumentToPatch {
 	required DocumentId DocumentId = 1;
 	optional Invoicing.Signer Signer = 2;
 	repeated Invoicing.Signers.ExtendedSigner ExtendedSigner = 3;
+	optional bytes SignerContent = 4;
 }
 
 message DocumentPatchedContent {

--- a/proto/Invoicing/ExtendedSigner.proto
+++ b/proto/Invoicing/ExtendedSigner.proto
@@ -39,7 +39,7 @@ message ExtendedSignerDetailsToPost {
 }
 
 enum SignerType {
-	SignerTypeUnspecified = 0;     // Не указано
+	SignerTypeUnspecified = -1;     // Не указано
 	LegalEntity = 1;                // Представитель юридического лица
 	IndividualEntity = 2;           // Индивидуальный предприниматель
 	PhysicalPerson = 3;             // Физическое лицо

--- a/proto/Invoicing/ExtendedSigner.proto
+++ b/proto/Invoicing/ExtendedSigner.proto
@@ -39,7 +39,7 @@ message ExtendedSignerDetailsToPost {
 }
 
 enum SignerType {
-	SignerTypeUnspecified = -1;     // Не указано
+	SignerTypeUnspecified = 0;     // Не указано
 	LegalEntity = 1;                // Представитель юридического лица
 	IndividualEntity = 2;           // Индивидуальный предприниматель
 	PhysicalPerson = 3;             // Физическое лицо

--- a/src/main/java/Diadoc/Api/Proto/CloudSignProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/CloudSignProtos.java
@@ -3,11 +3,11 @@
 
 package Diadoc.Api.Proto;
 
+@Deprecated
 public final class CloudSignProtos {
   private CloudSignProtos() {}
   public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
-    registry.add(Diadoc.Api.Proto.CloudSignProtos.fileDeprecated);
   }
   public interface CloudSignRequestOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.CloudSignRequest)
@@ -3186,17 +3186,6 @@ public final class CloudSignProtos {
     // @@protoc_insertion_point(class_scope:Diadoc.Api.Proto.AutosignReceiptsResult)
   }
 
-  public static final int FILE_DEPRECATED_FIELD_NUMBER = 50001;
-  /**
-   * <code>extend .google.protobuf.FileOptions { ... }</code>
-   */
-  public static final
-    com.google.protobuf.GeneratedMessage.GeneratedExtension<
-      com.google.protobuf.DescriptorProtos.FileOptions,
-      java.lang.Boolean> fileDeprecated = com.google.protobuf.GeneratedMessage
-          .newFileScopedGeneratedExtension(
-        java.lang.Boolean.class,
-        null);
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_Diadoc_Api_Proto_CloudSignRequest_descriptor;
   private static
@@ -3232,20 +3221,17 @@ public final class CloudSignProtos {
   static {
     java.lang.String[] descriptorData = {
       "\n\017CloudSign.proto\022\020Diadoc.Api.Proto\032\020Con" +
-      "tent_v2.proto\032 google/protobuf/descripto" +
-      "r.proto\"J\n\020CloudSignRequest\0222\n\005Files\030\001 \003" +
-      "(\0132\037.Diadoc.Api.Proto.CloudSignFileB\002\030\001:" +
-      "\002\030\001\"r\n\rCloudSignFile\0221\n\007Content\030\001 \001(\0132\034." +
-      "Diadoc.Api.Proto.Content_v2B\002\030\001\022\024\n\010FileN" +
-      "ame\030\002 \001(\tB\002\030\001\022\030\n\ndeprecated\030\003 \001(\010:\004true\"" +
-      "(\n\017CloudSignResult\022\021\n\005Token\030\001 \001(\tB\002\030\001:\002\030" +
-      "\001\"R\n\026CloudSignConfirmResult\0224\n\nSignature" +
-      "s\030\001 \003(\0132\034.Diadoc.Api.Proto.Content_v2B\002\030",
-      "\001:\002\030\001\"W\n\026AutosignReceiptsResult\022\037\n\023Signe" +
-      "dReceiptsCount\030\001 \002(\003B\002\030\001\022\030\n\014NextBatchKey" +
-      "\030\002 \002(\tB\002\030\001:\002\030\001:7\n\017file_deprecated\022\034.goog" +
-      "le.protobuf.FileOptions\030\321\206\003 \001(\010B\025B\017Cloud" +
-      "SignProtos\210\265\030\001"
+      "tent_v2.proto\"J\n\020CloudSignRequest\0222\n\005Fil" +
+      "es\030\001 \003(\0132\037.Diadoc.Api.Proto.CloudSignFil" +
+      "eB\002\030\001:\002\030\001\"r\n\rCloudSignFile\0221\n\007Content\030\001 " +
+      "\001(\0132\034.Diadoc.Api.Proto.Content_v2B\002\030\001\022\024\n" +
+      "\010FileName\030\002 \001(\tB\002\030\001\022\030\n\ndeprecated\030\003 \001(\010:" +
+      "\004true\"(\n\017CloudSignResult\022\021\n\005Token\030\001 \001(\tB" +
+      "\002\030\001:\002\030\001\"R\n\026CloudSignConfirmResult\0224\n\nSig" +
+      "natures\030\001 \003(\0132\034.Diadoc.Api.Proto.Content" +
+      "_v2B\002\030\001:\002\030\001\"W\n\026AutosignReceiptsResult\022\037\n",
+      "\023SignedReceiptsCount\030\001 \002(\003B\002\030\001\022\030\n\014NextBa" +
+      "tchKey\030\002 \002(\tB\002\030\001:\002\030\001B\021B\017CloudSignProtos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -3259,7 +3245,6 @@ public final class CloudSignProtos {
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
           Diadoc.Api.Proto.Content_v2Protos.getDescriptor(),
-          com.google.protobuf.DescriptorProtos.getDescriptor(),
         }, assigner);
     internal_static_Diadoc_Api_Proto_CloudSignRequest_descriptor =
       getDescriptor().getMessageTypes().get(0);
@@ -3291,14 +3276,7 @@ public final class CloudSignProtos {
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_descriptor,
         new java.lang.String[] { "SignedReceiptsCount", "NextBatchKey", });
-    fileDeprecated.internalInit(descriptor.getExtensions().get(0));
-    com.google.protobuf.ExtensionRegistry registry =
-        com.google.protobuf.ExtensionRegistry.newInstance();
-    registry.add(Diadoc.Api.Proto.CloudSignProtos.fileDeprecated);
-    com.google.protobuf.Descriptors.FileDescriptor
-        .internalUpdateFileDescriptor(descriptor, registry);
     Diadoc.Api.Proto.Content_v2Protos.getDescriptor();
-    com.google.protobuf.DescriptorProtos.getDescriptor();
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/src/main/java/Diadoc/Api/Proto/CloudSignProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/CloudSignProtos.java
@@ -3,46 +3,50 @@
 
 package Diadoc.Api.Proto;
 
+/**
+ * @deprecated Этот класс устарел и будет удалён в следующей мажорной версии.
+ */
+@Deprecated
 public final class CloudSignProtos {
   private CloudSignProtos() {}
   public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistry registry) {
+          com.google.protobuf.ExtensionRegistry registry) {
   }
   public interface CloudSignRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.CloudSignRequest)
-      com.google.protobuf.MessageOrBuilder {
+          // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.CloudSignRequest)
+          com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
      */
-    java.util.List<Diadoc.Api.Proto.CloudSignProtos.CloudSignFile> 
-        getFilesList();
+    @java.lang.Deprecated java.util.List<Diadoc.Api.Proto.CloudSignProtos.CloudSignFile>
+    getFilesList();
     /**
-     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
      */
-    Diadoc.Api.Proto.CloudSignProtos.CloudSignFile getFiles(int index);
+    @java.lang.Deprecated Diadoc.Api.Proto.CloudSignProtos.CloudSignFile getFiles(int index);
     /**
-     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
      */
-    int getFilesCount();
+    @java.lang.Deprecated int getFilesCount();
     /**
-     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
      */
-    java.util.List<? extends Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder> 
-        getFilesOrBuilderList();
+    @java.lang.Deprecated java.util.List<? extends Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder>
+    getFilesOrBuilderList();
     /**
-     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
      */
-    Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder getFilesOrBuilder(
-        int index);
+    @java.lang.Deprecated Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder getFilesOrBuilder(
+            int index);
   }
   /**
    * Protobuf type {@code Diadoc.Api.Proto.CloudSignRequest}
    */
   public static final class CloudSignRequest extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.CloudSignRequest)
-      CloudSignRequestOrBuilder {
+          com.google.protobuf.GeneratedMessage implements
+          // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.CloudSignRequest)
+          CloudSignRequestOrBuilder {
     // Use CloudSignRequest.newBuilder() to construct.
     private CloudSignRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -62,17 +66,17 @@ public final class CloudSignProtos {
     private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
+    getUnknownFields() {
       return this.unknownFields;
     }
     private CloudSignRequest(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       initFields();
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
+              com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -83,7 +87,7 @@ public final class CloudSignProtos {
               break;
             default: {
               if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
+                      extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -102,7 +106,7 @@ public final class CloudSignProtos {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
+                e.getMessage()).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
           files_ = java.util.Collections.unmodifiableList(files_);
@@ -112,26 +116,26 @@ public final class CloudSignProtos {
       }
     }
     public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
+    getDescriptor() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignRequest_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
+    internalGetFieldAccessorTable() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignRequest_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest.Builder.class);
+              .ensureFieldAccessorsInitialized(
+                      Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest.Builder.class);
     }
 
     public static com.google.protobuf.Parser<CloudSignRequest> PARSER =
-        new com.google.protobuf.AbstractParser<CloudSignRequest>() {
-      public CloudSignRequest parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CloudSignRequest(input, extensionRegistry);
-      }
-    };
+            new com.google.protobuf.AbstractParser<CloudSignRequest>() {
+              public CloudSignRequest parsePartialFrom(
+                      com.google.protobuf.CodedInputStream input,
+                      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                      throws com.google.protobuf.InvalidProtocolBufferException {
+                return new CloudSignRequest(input, extensionRegistry);
+              }
+            };
 
     @java.lang.Override
     public com.google.protobuf.Parser<CloudSignRequest> getParserForType() {
@@ -141,35 +145,35 @@ public final class CloudSignProtos {
     public static final int FILES_FIELD_NUMBER = 1;
     private java.util.List<Diadoc.Api.Proto.CloudSignProtos.CloudSignFile> files_;
     /**
-     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
      */
-    public java.util.List<Diadoc.Api.Proto.CloudSignProtos.CloudSignFile> getFilesList() {
+    @java.lang.Deprecated public java.util.List<Diadoc.Api.Proto.CloudSignProtos.CloudSignFile> getFilesList() {
       return files_;
     }
     /**
-     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
      */
-    public java.util.List<? extends Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder> 
-        getFilesOrBuilderList() {
+    @java.lang.Deprecated public java.util.List<? extends Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder>
+    getFilesOrBuilderList() {
       return files_;
     }
     /**
-     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
      */
-    public int getFilesCount() {
+    @java.lang.Deprecated public int getFilesCount() {
       return files_.size();
     }
     /**
-     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
      */
-    public Diadoc.Api.Proto.CloudSignProtos.CloudSignFile getFiles(int index) {
+    @java.lang.Deprecated public Diadoc.Api.Proto.CloudSignProtos.CloudSignFile getFiles(int index) {
       return files_.get(index);
     }
     /**
-     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
      */
-    public Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder getFilesOrBuilder(
-        int index) {
+    @java.lang.Deprecated public Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder getFilesOrBuilder(
+            int index) {
       return files_.get(index);
     }
 
@@ -193,7 +197,7 @@ public final class CloudSignProtos {
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
+            throws java.io.IOException {
       getSerializedSize();
       for (int i = 0; i < files_.size(); i++) {
         output.writeMessage(1, files_.get(i));
@@ -209,7 +213,7 @@ public final class CloudSignProtos {
       size = 0;
       for (int i = 0; i < files_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(1, files_.get(i));
+                .computeMessageSize(1, files_.get(i));
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -219,60 +223,60 @@ public final class CloudSignProtos {
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
+            throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
 
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.ByteString data)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.ByteString data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            byte[] data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
+            throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            java.io.InputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
+            throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            java.io.InputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
+            com.google.protobuf.CodedInputStream input)
+            throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
 
@@ -285,7 +289,7 @@ public final class CloudSignProtos {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -293,19 +297,19 @@ public final class CloudSignProtos {
      * Protobuf type {@code Diadoc.Api.Proto.CloudSignRequest}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.CloudSignRequest)
-        Diadoc.Api.Proto.CloudSignProtos.CloudSignRequestOrBuilder {
+            com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+            // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.CloudSignRequest)
+            Diadoc.Api.Proto.CloudSignProtos.CloudSignRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
+      getDescriptor() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignRequest_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
+      internalGetFieldAccessorTable() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignRequest_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest.Builder.class);
+                .ensureFieldAccessorsInitialized(
+                        Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest.Builder.class);
       }
 
       // Construct using Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest.newBuilder()
@@ -314,7 +318,7 @@ public final class CloudSignProtos {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+              com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -343,7 +347,7 @@ public final class CloudSignProtos {
       }
 
       public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
+      getDescriptorForType() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignRequest_descriptor;
       }
 
@@ -404,9 +408,9 @@ public final class CloudSignProtos {
               filesBuilder_ = null;
               files_ = other.files_;
               bitField0_ = (bitField0_ & ~0x00000001);
-              filesBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                   getFilesFieldBuilder() : null;
+              filesBuilder_ =
+                      com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                              getFilesFieldBuilder() : null;
             } else {
               filesBuilder_.addAllMessages(other.files_);
             }
@@ -419,7 +423,7 @@ public final class CloudSignProtos {
       public final boolean isInitialized() {
         for (int i = 0; i < getFilesCount(); i++) {
           if (!getFiles(i).isInitialized()) {
-            
+
             return false;
           }
         }
@@ -427,9 +431,9 @@ public final class CloudSignProtos {
       }
 
       public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
+              com.google.protobuf.CodedInputStream input,
+              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+              throws java.io.IOException {
         Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
@@ -446,21 +450,21 @@ public final class CloudSignProtos {
       private int bitField0_;
 
       private java.util.List<Diadoc.Api.Proto.CloudSignProtos.CloudSignFile> files_ =
-        java.util.Collections.emptyList();
+              java.util.Collections.emptyList();
       private void ensureFilesIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
           files_ = new java.util.ArrayList<Diadoc.Api.Proto.CloudSignProtos.CloudSignFile>(files_);
           bitField0_ |= 0x00000001;
-         }
+        }
       }
 
       private com.google.protobuf.RepeatedFieldBuilder<
-          Diadoc.Api.Proto.CloudSignProtos.CloudSignFile, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder, Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder> filesBuilder_;
+              Diadoc.Api.Proto.CloudSignProtos.CloudSignFile, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder, Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder> filesBuilder_;
 
       /**
-       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      public java.util.List<Diadoc.Api.Proto.CloudSignProtos.CloudSignFile> getFilesList() {
+      @java.lang.Deprecated public java.util.List<Diadoc.Api.Proto.CloudSignProtos.CloudSignFile> getFilesList() {
         if (filesBuilder_ == null) {
           return java.util.Collections.unmodifiableList(files_);
         } else {
@@ -468,9 +472,9 @@ public final class CloudSignProtos {
         }
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      public int getFilesCount() {
+      @java.lang.Deprecated public int getFilesCount() {
         if (filesBuilder_ == null) {
           return files_.size();
         } else {
@@ -478,9 +482,9 @@ public final class CloudSignProtos {
         }
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      public Diadoc.Api.Proto.CloudSignProtos.CloudSignFile getFiles(int index) {
+      @java.lang.Deprecated public Diadoc.Api.Proto.CloudSignProtos.CloudSignFile getFiles(int index) {
         if (filesBuilder_ == null) {
           return files_.get(index);
         } else {
@@ -488,10 +492,10 @@ public final class CloudSignProtos {
         }
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      public Builder setFiles(
-          int index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile value) {
+      @java.lang.Deprecated public Builder setFiles(
+              int index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile value) {
         if (filesBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -505,10 +509,10 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      public Builder setFiles(
-          int index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder builderForValue) {
+      @java.lang.Deprecated public Builder setFiles(
+              int index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder builderForValue) {
         if (filesBuilder_ == null) {
           ensureFilesIsMutable();
           files_.set(index, builderForValue.build());
@@ -519,9 +523,9 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      public Builder addFiles(Diadoc.Api.Proto.CloudSignProtos.CloudSignFile value) {
+      @java.lang.Deprecated public Builder addFiles(Diadoc.Api.Proto.CloudSignProtos.CloudSignFile value) {
         if (filesBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -535,10 +539,10 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      public Builder addFiles(
-          int index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile value) {
+      @java.lang.Deprecated public Builder addFiles(
+              int index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile value) {
         if (filesBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -552,10 +556,10 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      public Builder addFiles(
-          Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder builderForValue) {
+      @java.lang.Deprecated public Builder addFiles(
+              Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder builderForValue) {
         if (filesBuilder_ == null) {
           ensureFilesIsMutable();
           files_.add(builderForValue.build());
@@ -566,10 +570,10 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      public Builder addFiles(
-          int index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder builderForValue) {
+      @java.lang.Deprecated public Builder addFiles(
+              int index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder builderForValue) {
         if (filesBuilder_ == null) {
           ensureFilesIsMutable();
           files_.add(index, builderForValue.build());
@@ -580,14 +584,14 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      public Builder addAllFiles(
-          java.lang.Iterable<? extends Diadoc.Api.Proto.CloudSignProtos.CloudSignFile> values) {
+      @java.lang.Deprecated public Builder addAllFiles(
+              java.lang.Iterable<? extends Diadoc.Api.Proto.CloudSignProtos.CloudSignFile> values) {
         if (filesBuilder_ == null) {
           ensureFilesIsMutable();
           com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, files_);
+                  values, files_);
           onChanged();
         } else {
           filesBuilder_.addAllMessages(values);
@@ -595,9 +599,9 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      public Builder clearFiles() {
+      @java.lang.Deprecated public Builder clearFiles() {
         if (filesBuilder_ == null) {
           files_ = java.util.Collections.emptyList();
           bitField0_ = (bitField0_ & ~0x00000001);
@@ -608,9 +612,9 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      public Builder removeFiles(int index) {
+      @java.lang.Deprecated public Builder removeFiles(int index) {
         if (filesBuilder_ == null) {
           ensureFilesIsMutable();
           files_.remove(index);
@@ -621,27 +625,27 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      public Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder getFilesBuilder(
-          int index) {
+      @java.lang.Deprecated public Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder getFilesBuilder(
+              int index) {
         return getFilesFieldBuilder().getBuilder(index);
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      public Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder getFilesOrBuilder(
-          int index) {
+      @java.lang.Deprecated public Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder getFilesOrBuilder(
+              int index) {
         if (filesBuilder_ == null) {
           return files_.get(index);  } else {
           return filesBuilder_.getMessageOrBuilder(index);
         }
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      public java.util.List<? extends Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder> 
-           getFilesOrBuilderList() {
+      @java.lang.Deprecated public java.util.List<? extends Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder>
+      getFilesOrBuilderList() {
         if (filesBuilder_ != null) {
           return filesBuilder_.getMessageOrBuilderList();
         } else {
@@ -649,33 +653,33 @@ public final class CloudSignProtos {
         }
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      public Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder addFilesBuilder() {
+      @java.lang.Deprecated public Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder addFilesBuilder() {
         return getFilesFieldBuilder().addBuilder(
-            Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.getDefaultInstance());
+                Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.getDefaultInstance());
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      public Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder addFilesBuilder(
-          int index) {
+      @java.lang.Deprecated public Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder addFilesBuilder(
+              int index) {
         return getFilesFieldBuilder().addBuilder(
-            index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.getDefaultInstance());
+                index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.getDefaultInstance());
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      public java.util.List<Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder> 
-           getFilesBuilderList() {
+      @java.lang.Deprecated public java.util.List<Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder>
+      getFilesBuilderList() {
         return getFilesFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilder<
-          Diadoc.Api.Proto.CloudSignProtos.CloudSignFile, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder, Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder> 
-          getFilesFieldBuilder() {
+              Diadoc.Api.Proto.CloudSignProtos.CloudSignFile, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder, Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder>
+      getFilesFieldBuilder() {
         if (filesBuilder_ == null) {
           filesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              Diadoc.Api.Proto.CloudSignProtos.CloudSignFile, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder, Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder>(
+                  Diadoc.Api.Proto.CloudSignProtos.CloudSignFile, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder, Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder>(
                   files_,
                   ((bitField0_ & 0x00000001) == 0x00000001),
                   getParentForChildren(),
@@ -697,43 +701,43 @@ public final class CloudSignProtos {
   }
 
   public interface CloudSignFileOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.CloudSignFile)
-      com.google.protobuf.MessageOrBuilder {
+          // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.CloudSignFile)
+          com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1;</code>
+     * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1 [deprecated = true];</code>
      */
-    boolean hasContent();
+    @java.lang.Deprecated boolean hasContent();
     /**
-     * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1;</code>
+     * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1 [deprecated = true];</code>
      */
-    Diadoc.Api.Proto.Content_v2Protos.Content_v2 getContent();
+    @java.lang.Deprecated Diadoc.Api.Proto.Content_v2Protos.Content_v2 getContent();
     /**
-     * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1;</code>
+     * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1 [deprecated = true];</code>
      */
-    Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder getContentOrBuilder();
+    @java.lang.Deprecated Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder getContentOrBuilder();
 
     /**
-     * <code>optional string FileName = 2;</code>
+     * <code>optional string FileName = 2 [deprecated = true];</code>
      */
-    boolean hasFileName();
+    @java.lang.Deprecated boolean hasFileName();
     /**
-     * <code>optional string FileName = 2;</code>
+     * <code>optional string FileName = 2 [deprecated = true];</code>
      */
-    java.lang.String getFileName();
+    @java.lang.Deprecated java.lang.String getFileName();
     /**
-     * <code>optional string FileName = 2;</code>
+     * <code>optional string FileName = 2 [deprecated = true];</code>
      */
-    com.google.protobuf.ByteString
-        getFileNameBytes();
+    @java.lang.Deprecated com.google.protobuf.ByteString
+    getFileNameBytes();
   }
   /**
    * Protobuf type {@code Diadoc.Api.Proto.CloudSignFile}
    */
   public static final class CloudSignFile extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.CloudSignFile)
-      CloudSignFileOrBuilder {
+          com.google.protobuf.GeneratedMessage implements
+          // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.CloudSignFile)
+          CloudSignFileOrBuilder {
     // Use CloudSignFile.newBuilder() to construct.
     private CloudSignFile(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -753,17 +757,17 @@ public final class CloudSignProtos {
     private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
+    getUnknownFields() {
       return this.unknownFields;
     }
     private CloudSignFile(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       initFields();
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
+              com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -774,7 +778,7 @@ public final class CloudSignProtos {
               break;
             default: {
               if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
+                      extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -804,33 +808,33 @@ public final class CloudSignProtos {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
+                e.getMessage()).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
     }
     public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
+    getDescriptor() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignFile_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
+    internalGetFieldAccessorTable() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignFile_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder.class);
+              .ensureFieldAccessorsInitialized(
+                      Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder.class);
     }
 
     public static com.google.protobuf.Parser<CloudSignFile> PARSER =
-        new com.google.protobuf.AbstractParser<CloudSignFile>() {
-      public CloudSignFile parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CloudSignFile(input, extensionRegistry);
-      }
-    };
+            new com.google.protobuf.AbstractParser<CloudSignFile>() {
+              public CloudSignFile parsePartialFrom(
+                      com.google.protobuf.CodedInputStream input,
+                      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                      throws com.google.protobuf.InvalidProtocolBufferException {
+                return new CloudSignFile(input, extensionRegistry);
+              }
+            };
 
     @java.lang.Override
     public com.google.protobuf.Parser<CloudSignFile> getParserForType() {
@@ -841,42 +845,42 @@ public final class CloudSignProtos {
     public static final int CONTENT_FIELD_NUMBER = 1;
     private Diadoc.Api.Proto.Content_v2Protos.Content_v2 content_;
     /**
-     * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1;</code>
+     * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1 [deprecated = true];</code>
      */
-    public boolean hasContent() {
+    @java.lang.Deprecated public boolean hasContent() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1;</code>
+     * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1 [deprecated = true];</code>
      */
-    public Diadoc.Api.Proto.Content_v2Protos.Content_v2 getContent() {
+    @java.lang.Deprecated public Diadoc.Api.Proto.Content_v2Protos.Content_v2 getContent() {
       return content_;
     }
     /**
-     * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1;</code>
+     * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1 [deprecated = true];</code>
      */
-    public Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder getContentOrBuilder() {
+    @java.lang.Deprecated public Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder getContentOrBuilder() {
       return content_;
     }
 
     public static final int FILENAME_FIELD_NUMBER = 2;
     private java.lang.Object fileName_;
     /**
-     * <code>optional string FileName = 2;</code>
+     * <code>optional string FileName = 2 [deprecated = true];</code>
      */
-    public boolean hasFileName() {
+    @java.lang.Deprecated public boolean hasFileName() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional string FileName = 2;</code>
+     * <code>optional string FileName = 2 [deprecated = true];</code>
      */
-    public java.lang.String getFileName() {
+    @java.lang.Deprecated public java.lang.String getFileName() {
       java.lang.Object ref = fileName_;
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs =
+                (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           fileName_ = s;
@@ -885,15 +889,15 @@ public final class CloudSignProtos {
       }
     }
     /**
-     * <code>optional string FileName = 2;</code>
+     * <code>optional string FileName = 2 [deprecated = true];</code>
      */
-    public com.google.protobuf.ByteString
-        getFileNameBytes() {
+    @java.lang.Deprecated public com.google.protobuf.ByteString
+    getFileNameBytes() {
       java.lang.Object ref = fileName_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+                com.google.protobuf.ByteString.copyFromUtf8(
+                        (java.lang.String) ref);
         fileName_ = b;
         return b;
       } else {
@@ -922,7 +926,7 @@ public final class CloudSignProtos {
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
+            throws java.io.IOException {
       getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeMessage(1, content_);
@@ -941,11 +945,11 @@ public final class CloudSignProtos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(1, content_);
+                .computeMessageSize(1, content_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(2, getFileNameBytes());
+                .computeBytesSize(2, getFileNameBytes());
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -955,60 +959,60 @@ public final class CloudSignProtos {
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
+            throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
 
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.ByteString data)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.ByteString data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            byte[] data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
+            throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            java.io.InputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
+            throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            java.io.InputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
+            com.google.protobuf.CodedInputStream input)
+            throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
 
@@ -1021,7 +1025,7 @@ public final class CloudSignProtos {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -1029,19 +1033,19 @@ public final class CloudSignProtos {
      * Protobuf type {@code Diadoc.Api.Proto.CloudSignFile}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.CloudSignFile)
-        Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder {
+            com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+            // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.CloudSignFile)
+            Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
+      getDescriptor() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignFile_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
+      internalGetFieldAccessorTable() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignFile_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder.class);
+                .ensureFieldAccessorsInitialized(
+                        Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder.class);
       }
 
       // Construct using Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.newBuilder()
@@ -1050,7 +1054,7 @@ public final class CloudSignProtos {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+              com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -1081,7 +1085,7 @@ public final class CloudSignProtos {
       }
 
       public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
+      getDescriptorForType() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignFile_descriptor;
       }
 
@@ -1144,7 +1148,7 @@ public final class CloudSignProtos {
       public final boolean isInitialized() {
         if (hasContent()) {
           if (!getContent().isInitialized()) {
-            
+
             return false;
           }
         }
@@ -1152,9 +1156,9 @@ public final class CloudSignProtos {
       }
 
       public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
+              com.google.protobuf.CodedInputStream input,
+              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+              throws java.io.IOException {
         Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
@@ -1172,17 +1176,17 @@ public final class CloudSignProtos {
 
       private Diadoc.Api.Proto.Content_v2Protos.Content_v2 content_ = Diadoc.Api.Proto.Content_v2Protos.Content_v2.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
-          Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder> contentBuilder_;
+              Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder> contentBuilder_;
       /**
-       * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1;</code>
+       * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1 [deprecated = true];</code>
        */
-      public boolean hasContent() {
+      @java.lang.Deprecated public boolean hasContent() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
-       * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1;</code>
+       * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1 [deprecated = true];</code>
        */
-      public Diadoc.Api.Proto.Content_v2Protos.Content_v2 getContent() {
+      @java.lang.Deprecated public Diadoc.Api.Proto.Content_v2Protos.Content_v2 getContent() {
         if (contentBuilder_ == null) {
           return content_;
         } else {
@@ -1190,9 +1194,9 @@ public final class CloudSignProtos {
         }
       }
       /**
-       * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1;</code>
+       * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1 [deprecated = true];</code>
        */
-      public Builder setContent(Diadoc.Api.Proto.Content_v2Protos.Content_v2 value) {
+      @java.lang.Deprecated public Builder setContent(Diadoc.Api.Proto.Content_v2Protos.Content_v2 value) {
         if (contentBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -1206,10 +1210,10 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1;</code>
+       * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1 [deprecated = true];</code>
        */
-      public Builder setContent(
-          Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder builderForValue) {
+      @java.lang.Deprecated public Builder setContent(
+              Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder builderForValue) {
         if (contentBuilder_ == null) {
           content_ = builderForValue.build();
           onChanged();
@@ -1220,14 +1224,14 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1;</code>
+       * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1 [deprecated = true];</code>
        */
-      public Builder mergeContent(Diadoc.Api.Proto.Content_v2Protos.Content_v2 value) {
+      @java.lang.Deprecated public Builder mergeContent(Diadoc.Api.Proto.Content_v2Protos.Content_v2 value) {
         if (contentBuilder_ == null) {
           if (((bitField0_ & 0x00000001) == 0x00000001) &&
-              content_ != Diadoc.Api.Proto.Content_v2Protos.Content_v2.getDefaultInstance()) {
+                  content_ != Diadoc.Api.Proto.Content_v2Protos.Content_v2.getDefaultInstance()) {
             content_ =
-              Diadoc.Api.Proto.Content_v2Protos.Content_v2.newBuilder(content_).mergeFrom(value).buildPartial();
+                    Diadoc.Api.Proto.Content_v2Protos.Content_v2.newBuilder(content_).mergeFrom(value).buildPartial();
           } else {
             content_ = value;
           }
@@ -1239,9 +1243,9 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1;</code>
+       * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1 [deprecated = true];</code>
        */
-      public Builder clearContent() {
+      @java.lang.Deprecated public Builder clearContent() {
         if (contentBuilder_ == null) {
           content_ = Diadoc.Api.Proto.Content_v2Protos.Content_v2.getDefaultInstance();
           onChanged();
@@ -1252,17 +1256,17 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1;</code>
+       * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1 [deprecated = true];</code>
        */
-      public Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder getContentBuilder() {
+      @java.lang.Deprecated public Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder getContentBuilder() {
         bitField0_ |= 0x00000001;
         onChanged();
         return getContentFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1;</code>
+       * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1 [deprecated = true];</code>
        */
-      public Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder getContentOrBuilder() {
+      @java.lang.Deprecated public Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder getContentOrBuilder() {
         if (contentBuilder_ != null) {
           return contentBuilder_.getMessageOrBuilder();
         } else {
@@ -1270,14 +1274,14 @@ public final class CloudSignProtos {
         }
       }
       /**
-       * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1;</code>
+       * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1 [deprecated = true];</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
-          Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder> 
-          getContentFieldBuilder() {
+              Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder>
+      getContentFieldBuilder() {
         if (contentBuilder_ == null) {
           contentBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder>(
+                  Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder>(
                   getContent(),
                   getParentForChildren(),
                   isClean());
@@ -1288,19 +1292,19 @@ public final class CloudSignProtos {
 
       private java.lang.Object fileName_ = "";
       /**
-       * <code>optional string FileName = 2;</code>
+       * <code>optional string FileName = 2 [deprecated = true];</code>
        */
-      public boolean hasFileName() {
+      @java.lang.Deprecated public boolean hasFileName() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
       /**
-       * <code>optional string FileName = 2;</code>
+       * <code>optional string FileName = 2 [deprecated = true];</code>
        */
-      public java.lang.String getFileName() {
+      @java.lang.Deprecated public java.lang.String getFileName() {
         java.lang.Object ref = fileName_;
         if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
+                  (com.google.protobuf.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             fileName_ = s;
@@ -1311,15 +1315,15 @@ public final class CloudSignProtos {
         }
       }
       /**
-       * <code>optional string FileName = 2;</code>
+       * <code>optional string FileName = 2 [deprecated = true];</code>
        */
-      public com.google.protobuf.ByteString
-          getFileNameBytes() {
+      @java.lang.Deprecated public com.google.protobuf.ByteString
+      getFileNameBytes() {
         java.lang.Object ref = fileName_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
+          com.google.protobuf.ByteString b =
+                  com.google.protobuf.ByteString.copyFromUtf8(
+                          (java.lang.String) ref);
           fileName_ = b;
           return b;
         } else {
@@ -1327,36 +1331,36 @@ public final class CloudSignProtos {
         }
       }
       /**
-       * <code>optional string FileName = 2;</code>
+       * <code>optional string FileName = 2 [deprecated = true];</code>
        */
-      public Builder setFileName(
-          java.lang.String value) {
+      @java.lang.Deprecated public Builder setFileName(
+              java.lang.String value) {
         if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000002;
         fileName_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional string FileName = 2;</code>
+       * <code>optional string FileName = 2 [deprecated = true];</code>
        */
-      public Builder clearFileName() {
+      @java.lang.Deprecated public Builder clearFileName() {
         bitField0_ = (bitField0_ & ~0x00000002);
         fileName_ = getDefaultInstance().getFileName();
         onChanged();
         return this;
       }
       /**
-       * <code>optional string FileName = 2;</code>
+       * <code>optional string FileName = 2 [deprecated = true];</code>
        */
-      public Builder setFileNameBytes(
-          com.google.protobuf.ByteString value) {
+      @java.lang.Deprecated public Builder setFileNameBytes(
+              com.google.protobuf.ByteString value) {
         if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000002;
         fileName_ = value;
         onChanged();
         return this;
@@ -1374,30 +1378,30 @@ public final class CloudSignProtos {
   }
 
   public interface CloudSignResultOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.CloudSignResult)
-      com.google.protobuf.MessageOrBuilder {
+          // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.CloudSignResult)
+          com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional string Token = 1;</code>
+     * <code>optional string Token = 1 [deprecated = true];</code>
      */
-    boolean hasToken();
+    @java.lang.Deprecated boolean hasToken();
     /**
-     * <code>optional string Token = 1;</code>
+     * <code>optional string Token = 1 [deprecated = true];</code>
      */
-    java.lang.String getToken();
+    @java.lang.Deprecated java.lang.String getToken();
     /**
-     * <code>optional string Token = 1;</code>
+     * <code>optional string Token = 1 [deprecated = true];</code>
      */
-    com.google.protobuf.ByteString
-        getTokenBytes();
+    @java.lang.Deprecated com.google.protobuf.ByteString
+    getTokenBytes();
   }
   /**
    * Protobuf type {@code Diadoc.Api.Proto.CloudSignResult}
    */
   public static final class CloudSignResult extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.CloudSignResult)
-      CloudSignResultOrBuilder {
+          com.google.protobuf.GeneratedMessage implements
+          // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.CloudSignResult)
+          CloudSignResultOrBuilder {
     // Use CloudSignResult.newBuilder() to construct.
     private CloudSignResult(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -1417,17 +1421,17 @@ public final class CloudSignProtos {
     private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
+    getUnknownFields() {
       return this.unknownFields;
     }
     private CloudSignResult(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       initFields();
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
+              com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -1438,7 +1442,7 @@ public final class CloudSignProtos {
               break;
             default: {
               if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
+                      extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -1455,33 +1459,33 @@ public final class CloudSignProtos {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
+                e.getMessage()).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
     }
     public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
+    getDescriptor() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignResult_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
+    internalGetFieldAccessorTable() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignResult_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              Diadoc.Api.Proto.CloudSignProtos.CloudSignResult.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignResult.Builder.class);
+              .ensureFieldAccessorsInitialized(
+                      Diadoc.Api.Proto.CloudSignProtos.CloudSignResult.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignResult.Builder.class);
     }
 
     public static com.google.protobuf.Parser<CloudSignResult> PARSER =
-        new com.google.protobuf.AbstractParser<CloudSignResult>() {
-      public CloudSignResult parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CloudSignResult(input, extensionRegistry);
-      }
-    };
+            new com.google.protobuf.AbstractParser<CloudSignResult>() {
+              public CloudSignResult parsePartialFrom(
+                      com.google.protobuf.CodedInputStream input,
+                      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                      throws com.google.protobuf.InvalidProtocolBufferException {
+                return new CloudSignResult(input, extensionRegistry);
+              }
+            };
 
     @java.lang.Override
     public com.google.protobuf.Parser<CloudSignResult> getParserForType() {
@@ -1492,21 +1496,21 @@ public final class CloudSignProtos {
     public static final int TOKEN_FIELD_NUMBER = 1;
     private java.lang.Object token_;
     /**
-     * <code>optional string Token = 1;</code>
+     * <code>optional string Token = 1 [deprecated = true];</code>
      */
-    public boolean hasToken() {
+    @java.lang.Deprecated public boolean hasToken() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>optional string Token = 1;</code>
+     * <code>optional string Token = 1 [deprecated = true];</code>
      */
-    public java.lang.String getToken() {
+    @java.lang.Deprecated public java.lang.String getToken() {
       java.lang.Object ref = token_;
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs =
+                (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           token_ = s;
@@ -1515,15 +1519,15 @@ public final class CloudSignProtos {
       }
     }
     /**
-     * <code>optional string Token = 1;</code>
+     * <code>optional string Token = 1 [deprecated = true];</code>
      */
-    public com.google.protobuf.ByteString
-        getTokenBytes() {
+    @java.lang.Deprecated public com.google.protobuf.ByteString
+    getTokenBytes() {
       java.lang.Object ref = token_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+                com.google.protobuf.ByteString.copyFromUtf8(
+                        (java.lang.String) ref);
         token_ = b;
         return b;
       } else {
@@ -1545,7 +1549,7 @@ public final class CloudSignProtos {
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
+            throws java.io.IOException {
       getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeBytes(1, getTokenBytes());
@@ -1561,7 +1565,7 @@ public final class CloudSignProtos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(1, getTokenBytes());
+                .computeBytesSize(1, getTokenBytes());
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -1571,60 +1575,60 @@ public final class CloudSignProtos {
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
+            throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
 
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.ByteString data)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.ByteString data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            byte[] data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
+            throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            java.io.InputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
+            throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            java.io.InputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
+            com.google.protobuf.CodedInputStream input)
+            throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
 
@@ -1637,7 +1641,7 @@ public final class CloudSignProtos {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -1645,19 +1649,19 @@ public final class CloudSignProtos {
      * Protobuf type {@code Diadoc.Api.Proto.CloudSignResult}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.CloudSignResult)
-        Diadoc.Api.Proto.CloudSignProtos.CloudSignResultOrBuilder {
+            com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+            // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.CloudSignResult)
+            Diadoc.Api.Proto.CloudSignProtos.CloudSignResultOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
+      getDescriptor() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignResult_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
+      internalGetFieldAccessorTable() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignResult_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                Diadoc.Api.Proto.CloudSignProtos.CloudSignResult.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignResult.Builder.class);
+                .ensureFieldAccessorsInitialized(
+                        Diadoc.Api.Proto.CloudSignProtos.CloudSignResult.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignResult.Builder.class);
       }
 
       // Construct using Diadoc.Api.Proto.CloudSignProtos.CloudSignResult.newBuilder()
@@ -1666,7 +1670,7 @@ public final class CloudSignProtos {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+              com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -1690,7 +1694,7 @@ public final class CloudSignProtos {
       }
 
       public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
+      getDescriptorForType() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignResult_descriptor;
       }
 
@@ -1744,9 +1748,9 @@ public final class CloudSignProtos {
       }
 
       public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
+              com.google.protobuf.CodedInputStream input,
+              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+              throws java.io.IOException {
         Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
@@ -1764,19 +1768,19 @@ public final class CloudSignProtos {
 
       private java.lang.Object token_ = "";
       /**
-       * <code>optional string Token = 1;</code>
+       * <code>optional string Token = 1 [deprecated = true];</code>
        */
-      public boolean hasToken() {
+      @java.lang.Deprecated public boolean hasToken() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
-       * <code>optional string Token = 1;</code>
+       * <code>optional string Token = 1 [deprecated = true];</code>
        */
-      public java.lang.String getToken() {
+      @java.lang.Deprecated public java.lang.String getToken() {
         java.lang.Object ref = token_;
         if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
+                  (com.google.protobuf.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             token_ = s;
@@ -1787,15 +1791,15 @@ public final class CloudSignProtos {
         }
       }
       /**
-       * <code>optional string Token = 1;</code>
+       * <code>optional string Token = 1 [deprecated = true];</code>
        */
-      public com.google.protobuf.ByteString
-          getTokenBytes() {
+      @java.lang.Deprecated public com.google.protobuf.ByteString
+      getTokenBytes() {
         java.lang.Object ref = token_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
+          com.google.protobuf.ByteString b =
+                  com.google.protobuf.ByteString.copyFromUtf8(
+                          (java.lang.String) ref);
           token_ = b;
           return b;
         } else {
@@ -1803,36 +1807,36 @@ public final class CloudSignProtos {
         }
       }
       /**
-       * <code>optional string Token = 1;</code>
+       * <code>optional string Token = 1 [deprecated = true];</code>
        */
-      public Builder setToken(
-          java.lang.String value) {
+      @java.lang.Deprecated public Builder setToken(
+              java.lang.String value) {
         if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000001;
         token_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional string Token = 1;</code>
+       * <code>optional string Token = 1 [deprecated = true];</code>
        */
-      public Builder clearToken() {
+      @java.lang.Deprecated public Builder clearToken() {
         bitField0_ = (bitField0_ & ~0x00000001);
         token_ = getDefaultInstance().getToken();
         onChanged();
         return this;
       }
       /**
-       * <code>optional string Token = 1;</code>
+       * <code>optional string Token = 1 [deprecated = true];</code>
        */
-      public Builder setTokenBytes(
-          com.google.protobuf.ByteString value) {
+      @java.lang.Deprecated public Builder setTokenBytes(
+              com.google.protobuf.ByteString value) {
         if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000001;
         token_ = value;
         onChanged();
         return this;
@@ -1850,40 +1854,40 @@ public final class CloudSignProtos {
   }
 
   public interface CloudSignConfirmResultOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.CloudSignConfirmResult)
-      com.google.protobuf.MessageOrBuilder {
+          // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.CloudSignConfirmResult)
+          com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
      */
-    java.util.List<Diadoc.Api.Proto.Content_v2Protos.Content_v2> 
-        getSignaturesList();
+    @java.lang.Deprecated java.util.List<Diadoc.Api.Proto.Content_v2Protos.Content_v2>
+    getSignaturesList();
     /**
-     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
      */
-    Diadoc.Api.Proto.Content_v2Protos.Content_v2 getSignatures(int index);
+    @java.lang.Deprecated Diadoc.Api.Proto.Content_v2Protos.Content_v2 getSignatures(int index);
     /**
-     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
      */
-    int getSignaturesCount();
+    @java.lang.Deprecated int getSignaturesCount();
     /**
-     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
      */
-    java.util.List<? extends Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder> 
-        getSignaturesOrBuilderList();
+    @java.lang.Deprecated java.util.List<? extends Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder>
+    getSignaturesOrBuilderList();
     /**
-     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
      */
-    Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder getSignaturesOrBuilder(
-        int index);
+    @java.lang.Deprecated Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder getSignaturesOrBuilder(
+            int index);
   }
   /**
    * Protobuf type {@code Diadoc.Api.Proto.CloudSignConfirmResult}
    */
   public static final class CloudSignConfirmResult extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.CloudSignConfirmResult)
-      CloudSignConfirmResultOrBuilder {
+          com.google.protobuf.GeneratedMessage implements
+          // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.CloudSignConfirmResult)
+          CloudSignConfirmResultOrBuilder {
     // Use CloudSignConfirmResult.newBuilder() to construct.
     private CloudSignConfirmResult(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -1903,17 +1907,17 @@ public final class CloudSignProtos {
     private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
+    getUnknownFields() {
       return this.unknownFields;
     }
     private CloudSignConfirmResult(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       initFields();
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
+              com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -1924,7 +1928,7 @@ public final class CloudSignProtos {
               break;
             default: {
               if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
+                      extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -1943,7 +1947,7 @@ public final class CloudSignProtos {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
+                e.getMessage()).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
           signatures_ = java.util.Collections.unmodifiableList(signatures_);
@@ -1953,26 +1957,26 @@ public final class CloudSignProtos {
       }
     }
     public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
+    getDescriptor() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
+    internalGetFieldAccessorTable() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult.Builder.class);
+              .ensureFieldAccessorsInitialized(
+                      Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult.Builder.class);
     }
 
     public static com.google.protobuf.Parser<CloudSignConfirmResult> PARSER =
-        new com.google.protobuf.AbstractParser<CloudSignConfirmResult>() {
-      public CloudSignConfirmResult parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CloudSignConfirmResult(input, extensionRegistry);
-      }
-    };
+            new com.google.protobuf.AbstractParser<CloudSignConfirmResult>() {
+              public CloudSignConfirmResult parsePartialFrom(
+                      com.google.protobuf.CodedInputStream input,
+                      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                      throws com.google.protobuf.InvalidProtocolBufferException {
+                return new CloudSignConfirmResult(input, extensionRegistry);
+              }
+            };
 
     @java.lang.Override
     public com.google.protobuf.Parser<CloudSignConfirmResult> getParserForType() {
@@ -1982,35 +1986,35 @@ public final class CloudSignProtos {
     public static final int SIGNATURES_FIELD_NUMBER = 1;
     private java.util.List<Diadoc.Api.Proto.Content_v2Protos.Content_v2> signatures_;
     /**
-     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
      */
-    public java.util.List<Diadoc.Api.Proto.Content_v2Protos.Content_v2> getSignaturesList() {
+    @java.lang.Deprecated public java.util.List<Diadoc.Api.Proto.Content_v2Protos.Content_v2> getSignaturesList() {
       return signatures_;
     }
     /**
-     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
      */
-    public java.util.List<? extends Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder> 
-        getSignaturesOrBuilderList() {
+    @java.lang.Deprecated public java.util.List<? extends Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder>
+    getSignaturesOrBuilderList() {
       return signatures_;
     }
     /**
-     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
      */
-    public int getSignaturesCount() {
+    @java.lang.Deprecated public int getSignaturesCount() {
       return signatures_.size();
     }
     /**
-     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
      */
-    public Diadoc.Api.Proto.Content_v2Protos.Content_v2 getSignatures(int index) {
+    @java.lang.Deprecated public Diadoc.Api.Proto.Content_v2Protos.Content_v2 getSignatures(int index) {
       return signatures_.get(index);
     }
     /**
-     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+     * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
      */
-    public Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder getSignaturesOrBuilder(
-        int index) {
+    @java.lang.Deprecated public Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder getSignaturesOrBuilder(
+            int index) {
       return signatures_.get(index);
     }
 
@@ -2034,7 +2038,7 @@ public final class CloudSignProtos {
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
+            throws java.io.IOException {
       getSerializedSize();
       for (int i = 0; i < signatures_.size(); i++) {
         output.writeMessage(1, signatures_.get(i));
@@ -2050,7 +2054,7 @@ public final class CloudSignProtos {
       size = 0;
       for (int i = 0; i < signatures_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(1, signatures_.get(i));
+                .computeMessageSize(1, signatures_.get(i));
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -2060,60 +2064,60 @@ public final class CloudSignProtos {
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
+            throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
 
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.ByteString data)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.ByteString data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            byte[] data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
+            throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            java.io.InputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
+            throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            java.io.InputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
+            com.google.protobuf.CodedInputStream input)
+            throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
 
@@ -2126,7 +2130,7 @@ public final class CloudSignProtos {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -2134,19 +2138,19 @@ public final class CloudSignProtos {
      * Protobuf type {@code Diadoc.Api.Proto.CloudSignConfirmResult}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.CloudSignConfirmResult)
-        Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResultOrBuilder {
+            com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+            // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.CloudSignConfirmResult)
+            Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResultOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
+      getDescriptor() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
+      internalGetFieldAccessorTable() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult.Builder.class);
+                .ensureFieldAccessorsInitialized(
+                        Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult.Builder.class);
       }
 
       // Construct using Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult.newBuilder()
@@ -2155,7 +2159,7 @@ public final class CloudSignProtos {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+              com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -2184,7 +2188,7 @@ public final class CloudSignProtos {
       }
 
       public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
+      getDescriptorForType() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_descriptor;
       }
 
@@ -2245,9 +2249,9 @@ public final class CloudSignProtos {
               signaturesBuilder_ = null;
               signatures_ = other.signatures_;
               bitField0_ = (bitField0_ & ~0x00000001);
-              signaturesBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                   getSignaturesFieldBuilder() : null;
+              signaturesBuilder_ =
+                      com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                              getSignaturesFieldBuilder() : null;
             } else {
               signaturesBuilder_.addAllMessages(other.signatures_);
             }
@@ -2260,7 +2264,7 @@ public final class CloudSignProtos {
       public final boolean isInitialized() {
         for (int i = 0; i < getSignaturesCount(); i++) {
           if (!getSignatures(i).isInitialized()) {
-            
+
             return false;
           }
         }
@@ -2268,9 +2272,9 @@ public final class CloudSignProtos {
       }
 
       public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
+              com.google.protobuf.CodedInputStream input,
+              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+              throws java.io.IOException {
         Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
@@ -2287,21 +2291,21 @@ public final class CloudSignProtos {
       private int bitField0_;
 
       private java.util.List<Diadoc.Api.Proto.Content_v2Protos.Content_v2> signatures_ =
-        java.util.Collections.emptyList();
+              java.util.Collections.emptyList();
       private void ensureSignaturesIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
           signatures_ = new java.util.ArrayList<Diadoc.Api.Proto.Content_v2Protos.Content_v2>(signatures_);
           bitField0_ |= 0x00000001;
-         }
+        }
       }
 
       private com.google.protobuf.RepeatedFieldBuilder<
-          Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder> signaturesBuilder_;
+              Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder> signaturesBuilder_;
 
       /**
-       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      public java.util.List<Diadoc.Api.Proto.Content_v2Protos.Content_v2> getSignaturesList() {
+      @java.lang.Deprecated public java.util.List<Diadoc.Api.Proto.Content_v2Protos.Content_v2> getSignaturesList() {
         if (signaturesBuilder_ == null) {
           return java.util.Collections.unmodifiableList(signatures_);
         } else {
@@ -2309,9 +2313,9 @@ public final class CloudSignProtos {
         }
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      public int getSignaturesCount() {
+      @java.lang.Deprecated public int getSignaturesCount() {
         if (signaturesBuilder_ == null) {
           return signatures_.size();
         } else {
@@ -2319,9 +2323,9 @@ public final class CloudSignProtos {
         }
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      public Diadoc.Api.Proto.Content_v2Protos.Content_v2 getSignatures(int index) {
+      @java.lang.Deprecated public Diadoc.Api.Proto.Content_v2Protos.Content_v2 getSignatures(int index) {
         if (signaturesBuilder_ == null) {
           return signatures_.get(index);
         } else {
@@ -2329,10 +2333,10 @@ public final class CloudSignProtos {
         }
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      public Builder setSignatures(
-          int index, Diadoc.Api.Proto.Content_v2Protos.Content_v2 value) {
+      @java.lang.Deprecated public Builder setSignatures(
+              int index, Diadoc.Api.Proto.Content_v2Protos.Content_v2 value) {
         if (signaturesBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -2346,10 +2350,10 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      public Builder setSignatures(
-          int index, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder builderForValue) {
+      @java.lang.Deprecated public Builder setSignatures(
+              int index, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder builderForValue) {
         if (signaturesBuilder_ == null) {
           ensureSignaturesIsMutable();
           signatures_.set(index, builderForValue.build());
@@ -2360,9 +2364,9 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      public Builder addSignatures(Diadoc.Api.Proto.Content_v2Protos.Content_v2 value) {
+      @java.lang.Deprecated public Builder addSignatures(Diadoc.Api.Proto.Content_v2Protos.Content_v2 value) {
         if (signaturesBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -2376,10 +2380,10 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      public Builder addSignatures(
-          int index, Diadoc.Api.Proto.Content_v2Protos.Content_v2 value) {
+      @java.lang.Deprecated public Builder addSignatures(
+              int index, Diadoc.Api.Proto.Content_v2Protos.Content_v2 value) {
         if (signaturesBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -2393,10 +2397,10 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      public Builder addSignatures(
-          Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder builderForValue) {
+      @java.lang.Deprecated public Builder addSignatures(
+              Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder builderForValue) {
         if (signaturesBuilder_ == null) {
           ensureSignaturesIsMutable();
           signatures_.add(builderForValue.build());
@@ -2407,10 +2411,10 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      public Builder addSignatures(
-          int index, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder builderForValue) {
+      @java.lang.Deprecated public Builder addSignatures(
+              int index, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder builderForValue) {
         if (signaturesBuilder_ == null) {
           ensureSignaturesIsMutable();
           signatures_.add(index, builderForValue.build());
@@ -2421,14 +2425,14 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      public Builder addAllSignatures(
-          java.lang.Iterable<? extends Diadoc.Api.Proto.Content_v2Protos.Content_v2> values) {
+      @java.lang.Deprecated public Builder addAllSignatures(
+              java.lang.Iterable<? extends Diadoc.Api.Proto.Content_v2Protos.Content_v2> values) {
         if (signaturesBuilder_ == null) {
           ensureSignaturesIsMutable();
           com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, signatures_);
+                  values, signatures_);
           onChanged();
         } else {
           signaturesBuilder_.addAllMessages(values);
@@ -2436,9 +2440,9 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      public Builder clearSignatures() {
+      @java.lang.Deprecated public Builder clearSignatures() {
         if (signaturesBuilder_ == null) {
           signatures_ = java.util.Collections.emptyList();
           bitField0_ = (bitField0_ & ~0x00000001);
@@ -2449,9 +2453,9 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      public Builder removeSignatures(int index) {
+      @java.lang.Deprecated public Builder removeSignatures(int index) {
         if (signaturesBuilder_ == null) {
           ensureSignaturesIsMutable();
           signatures_.remove(index);
@@ -2462,27 +2466,27 @@ public final class CloudSignProtos {
         return this;
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      public Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder getSignaturesBuilder(
-          int index) {
+      @java.lang.Deprecated public Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder getSignaturesBuilder(
+              int index) {
         return getSignaturesFieldBuilder().getBuilder(index);
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      public Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder getSignaturesOrBuilder(
-          int index) {
+      @java.lang.Deprecated public Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder getSignaturesOrBuilder(
+              int index) {
         if (signaturesBuilder_ == null) {
           return signatures_.get(index);  } else {
           return signaturesBuilder_.getMessageOrBuilder(index);
         }
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      public java.util.List<? extends Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder> 
-           getSignaturesOrBuilderList() {
+      @java.lang.Deprecated public java.util.List<? extends Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder>
+      getSignaturesOrBuilderList() {
         if (signaturesBuilder_ != null) {
           return signaturesBuilder_.getMessageOrBuilderList();
         } else {
@@ -2490,33 +2494,33 @@ public final class CloudSignProtos {
         }
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      public Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder addSignaturesBuilder() {
+      @java.lang.Deprecated public Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder addSignaturesBuilder() {
         return getSignaturesFieldBuilder().addBuilder(
-            Diadoc.Api.Proto.Content_v2Protos.Content_v2.getDefaultInstance());
+                Diadoc.Api.Proto.Content_v2Protos.Content_v2.getDefaultInstance());
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      public Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder addSignaturesBuilder(
-          int index) {
+      @java.lang.Deprecated public Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder addSignaturesBuilder(
+              int index) {
         return getSignaturesFieldBuilder().addBuilder(
-            index, Diadoc.Api.Proto.Content_v2Protos.Content_v2.getDefaultInstance());
+                index, Diadoc.Api.Proto.Content_v2Protos.Content_v2.getDefaultInstance());
       }
       /**
-       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1;</code>
+       * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      public java.util.List<Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder> 
-           getSignaturesBuilderList() {
+      @java.lang.Deprecated public java.util.List<Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder>
+      getSignaturesBuilderList() {
         return getSignaturesFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilder<
-          Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder> 
-          getSignaturesFieldBuilder() {
+              Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder>
+      getSignaturesFieldBuilder() {
         if (signaturesBuilder_ == null) {
           signaturesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-              Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder>(
+                  Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder>(
                   signatures_,
                   ((bitField0_ & 0x00000001) == 0x00000001),
                   getParentForChildren(),
@@ -2538,39 +2542,39 @@ public final class CloudSignProtos {
   }
 
   public interface AutosignReceiptsResultOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.AutosignReceiptsResult)
-      com.google.protobuf.MessageOrBuilder {
+          // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.AutosignReceiptsResult)
+          com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>required int64 SignedReceiptsCount = 1;</code>
+     * <code>required int64 SignedReceiptsCount = 1 [deprecated = true];</code>
      */
-    boolean hasSignedReceiptsCount();
+    @java.lang.Deprecated boolean hasSignedReceiptsCount();
     /**
-     * <code>required int64 SignedReceiptsCount = 1;</code>
+     * <code>required int64 SignedReceiptsCount = 1 [deprecated = true];</code>
      */
-    long getSignedReceiptsCount();
+    @java.lang.Deprecated long getSignedReceiptsCount();
 
     /**
-     * <code>required string NextBatchKey = 2;</code>
+     * <code>required string NextBatchKey = 2 [deprecated = true];</code>
      */
-    boolean hasNextBatchKey();
+    @java.lang.Deprecated boolean hasNextBatchKey();
     /**
-     * <code>required string NextBatchKey = 2;</code>
+     * <code>required string NextBatchKey = 2 [deprecated = true];</code>
      */
-    java.lang.String getNextBatchKey();
+    @java.lang.Deprecated java.lang.String getNextBatchKey();
     /**
-     * <code>required string NextBatchKey = 2;</code>
+     * <code>required string NextBatchKey = 2 [deprecated = true];</code>
      */
-    com.google.protobuf.ByteString
-        getNextBatchKeyBytes();
+    @java.lang.Deprecated com.google.protobuf.ByteString
+    getNextBatchKeyBytes();
   }
   /**
    * Protobuf type {@code Diadoc.Api.Proto.AutosignReceiptsResult}
    */
   public static final class AutosignReceiptsResult extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.AutosignReceiptsResult)
-      AutosignReceiptsResultOrBuilder {
+          com.google.protobuf.GeneratedMessage implements
+          // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.AutosignReceiptsResult)
+          AutosignReceiptsResultOrBuilder {
     // Use AutosignReceiptsResult.newBuilder() to construct.
     private AutosignReceiptsResult(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -2590,17 +2594,17 @@ public final class CloudSignProtos {
     private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
+    getUnknownFields() {
       return this.unknownFields;
     }
     private AutosignReceiptsResult(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       initFields();
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
+              com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -2611,7 +2615,7 @@ public final class CloudSignProtos {
               break;
             default: {
               if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
+                      extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -2633,33 +2637,33 @@ public final class CloudSignProtos {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
+                e.getMessage()).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
     }
     public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
+    getDescriptor() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
+    internalGetFieldAccessorTable() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult.class, Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult.Builder.class);
+              .ensureFieldAccessorsInitialized(
+                      Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult.class, Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult.Builder.class);
     }
 
     public static com.google.protobuf.Parser<AutosignReceiptsResult> PARSER =
-        new com.google.protobuf.AbstractParser<AutosignReceiptsResult>() {
-      public AutosignReceiptsResult parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new AutosignReceiptsResult(input, extensionRegistry);
-      }
-    };
+            new com.google.protobuf.AbstractParser<AutosignReceiptsResult>() {
+              public AutosignReceiptsResult parsePartialFrom(
+                      com.google.protobuf.CodedInputStream input,
+                      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                      throws com.google.protobuf.InvalidProtocolBufferException {
+                return new AutosignReceiptsResult(input, extensionRegistry);
+              }
+            };
 
     @java.lang.Override
     public com.google.protobuf.Parser<AutosignReceiptsResult> getParserForType() {
@@ -2670,36 +2674,36 @@ public final class CloudSignProtos {
     public static final int SIGNEDRECEIPTSCOUNT_FIELD_NUMBER = 1;
     private long signedReceiptsCount_;
     /**
-     * <code>required int64 SignedReceiptsCount = 1;</code>
+     * <code>required int64 SignedReceiptsCount = 1 [deprecated = true];</code>
      */
-    public boolean hasSignedReceiptsCount() {
+    @java.lang.Deprecated public boolean hasSignedReceiptsCount() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required int64 SignedReceiptsCount = 1;</code>
+     * <code>required int64 SignedReceiptsCount = 1 [deprecated = true];</code>
      */
-    public long getSignedReceiptsCount() {
+    @java.lang.Deprecated public long getSignedReceiptsCount() {
       return signedReceiptsCount_;
     }
 
     public static final int NEXTBATCHKEY_FIELD_NUMBER = 2;
     private java.lang.Object nextBatchKey_;
     /**
-     * <code>required string NextBatchKey = 2;</code>
+     * <code>required string NextBatchKey = 2 [deprecated = true];</code>
      */
-    public boolean hasNextBatchKey() {
+    @java.lang.Deprecated public boolean hasNextBatchKey() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>required string NextBatchKey = 2;</code>
+     * <code>required string NextBatchKey = 2 [deprecated = true];</code>
      */
-    public java.lang.String getNextBatchKey() {
+    @java.lang.Deprecated public java.lang.String getNextBatchKey() {
       java.lang.Object ref = nextBatchKey_;
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs =
+                (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           nextBatchKey_ = s;
@@ -2708,15 +2712,15 @@ public final class CloudSignProtos {
       }
     }
     /**
-     * <code>required string NextBatchKey = 2;</code>
+     * <code>required string NextBatchKey = 2 [deprecated = true];</code>
      */
-    public com.google.protobuf.ByteString
-        getNextBatchKeyBytes() {
+    @java.lang.Deprecated public com.google.protobuf.ByteString
+    getNextBatchKeyBytes() {
       java.lang.Object ref = nextBatchKey_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+                com.google.protobuf.ByteString.copyFromUtf8(
+                        (java.lang.String) ref);
         nextBatchKey_ = b;
         return b;
       } else {
@@ -2747,7 +2751,7 @@ public final class CloudSignProtos {
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
+            throws java.io.IOException {
       getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeInt64(1, signedReceiptsCount_);
@@ -2766,11 +2770,11 @@ public final class CloudSignProtos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(1, signedReceiptsCount_);
+                .computeInt64Size(1, signedReceiptsCount_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(2, getNextBatchKeyBytes());
+                .computeBytesSize(2, getNextBatchKeyBytes());
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -2780,60 +2784,60 @@ public final class CloudSignProtos {
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
+            throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
 
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.ByteString data)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            com.google.protobuf.ByteString data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+            byte[] data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
+            throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            java.io.InputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
+            throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            java.io.InputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
+            com.google.protobuf.CodedInputStream input)
+            throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
 
@@ -2846,7 +2850,7 @@ public final class CloudSignProtos {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -2854,19 +2858,19 @@ public final class CloudSignProtos {
      * Protobuf type {@code Diadoc.Api.Proto.AutosignReceiptsResult}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.AutosignReceiptsResult)
-        Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResultOrBuilder {
+            com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+            // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.AutosignReceiptsResult)
+            Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResultOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
+      getDescriptor() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
+      internalGetFieldAccessorTable() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult.class, Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult.Builder.class);
+                .ensureFieldAccessorsInitialized(
+                        Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult.class, Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult.Builder.class);
       }
 
       // Construct using Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult.newBuilder()
@@ -2875,7 +2879,7 @@ public final class CloudSignProtos {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+              com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -2901,7 +2905,7 @@ public final class CloudSignProtos {
       }
 
       public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
+      getDescriptorForType() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_descriptor;
       }
 
@@ -2959,20 +2963,20 @@ public final class CloudSignProtos {
 
       public final boolean isInitialized() {
         if (!hasSignedReceiptsCount()) {
-          
+
           return false;
         }
         if (!hasNextBatchKey()) {
-          
+
           return false;
         }
         return true;
       }
 
       public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
+              com.google.protobuf.CodedInputStream input,
+              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+              throws java.io.IOException {
         Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
@@ -2990,30 +2994,30 @@ public final class CloudSignProtos {
 
       private long signedReceiptsCount_ ;
       /**
-       * <code>required int64 SignedReceiptsCount = 1;</code>
+       * <code>required int64 SignedReceiptsCount = 1 [deprecated = true];</code>
        */
-      public boolean hasSignedReceiptsCount() {
+      @java.lang.Deprecated public boolean hasSignedReceiptsCount() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
-       * <code>required int64 SignedReceiptsCount = 1;</code>
+       * <code>required int64 SignedReceiptsCount = 1 [deprecated = true];</code>
        */
-      public long getSignedReceiptsCount() {
+      @java.lang.Deprecated public long getSignedReceiptsCount() {
         return signedReceiptsCount_;
       }
       /**
-       * <code>required int64 SignedReceiptsCount = 1;</code>
+       * <code>required int64 SignedReceiptsCount = 1 [deprecated = true];</code>
        */
-      public Builder setSignedReceiptsCount(long value) {
+      @java.lang.Deprecated public Builder setSignedReceiptsCount(long value) {
         bitField0_ |= 0x00000001;
         signedReceiptsCount_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>required int64 SignedReceiptsCount = 1;</code>
+       * <code>required int64 SignedReceiptsCount = 1 [deprecated = true];</code>
        */
-      public Builder clearSignedReceiptsCount() {
+      @java.lang.Deprecated public Builder clearSignedReceiptsCount() {
         bitField0_ = (bitField0_ & ~0x00000001);
         signedReceiptsCount_ = 0L;
         onChanged();
@@ -3022,19 +3026,19 @@ public final class CloudSignProtos {
 
       private java.lang.Object nextBatchKey_ = "";
       /**
-       * <code>required string NextBatchKey = 2;</code>
+       * <code>required string NextBatchKey = 2 [deprecated = true];</code>
        */
-      public boolean hasNextBatchKey() {
+      @java.lang.Deprecated public boolean hasNextBatchKey() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
       /**
-       * <code>required string NextBatchKey = 2;</code>
+       * <code>required string NextBatchKey = 2 [deprecated = true];</code>
        */
-      public java.lang.String getNextBatchKey() {
+      @java.lang.Deprecated public java.lang.String getNextBatchKey() {
         java.lang.Object ref = nextBatchKey_;
         if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
+                  (com.google.protobuf.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             nextBatchKey_ = s;
@@ -3045,15 +3049,15 @@ public final class CloudSignProtos {
         }
       }
       /**
-       * <code>required string NextBatchKey = 2;</code>
+       * <code>required string NextBatchKey = 2 [deprecated = true];</code>
        */
-      public com.google.protobuf.ByteString
-          getNextBatchKeyBytes() {
+      @java.lang.Deprecated public com.google.protobuf.ByteString
+      getNextBatchKeyBytes() {
         java.lang.Object ref = nextBatchKey_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
+          com.google.protobuf.ByteString b =
+                  com.google.protobuf.ByteString.copyFromUtf8(
+                          (java.lang.String) ref);
           nextBatchKey_ = b;
           return b;
         } else {
@@ -3061,36 +3065,36 @@ public final class CloudSignProtos {
         }
       }
       /**
-       * <code>required string NextBatchKey = 2;</code>
+       * <code>required string NextBatchKey = 2 [deprecated = true];</code>
        */
-      public Builder setNextBatchKey(
-          java.lang.String value) {
+      @java.lang.Deprecated public Builder setNextBatchKey(
+              java.lang.String value) {
         if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000002;
         nextBatchKey_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>required string NextBatchKey = 2;</code>
+       * <code>required string NextBatchKey = 2 [deprecated = true];</code>
        */
-      public Builder clearNextBatchKey() {
+      @java.lang.Deprecated public Builder clearNextBatchKey() {
         bitField0_ = (bitField0_ & ~0x00000002);
         nextBatchKey_ = getDefaultInstance().getNextBatchKey();
         onChanged();
         return this;
       }
       /**
-       * <code>required string NextBatchKey = 2;</code>
+       * <code>required string NextBatchKey = 2 [deprecated = true];</code>
        */
-      public Builder setNextBatchKeyBytes(
-          com.google.protobuf.ByteString value) {
+      @java.lang.Deprecated public Builder setNextBatchKeyBytes(
+              com.google.protobuf.ByteString value) {
         if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000002;
         nextBatchKey_ = value;
         onChanged();
         return this;
@@ -3108,94 +3112,94 @@ public final class CloudSignProtos {
   }
 
   private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_Diadoc_Api_Proto_CloudSignRequest_descriptor;
+          internal_static_Diadoc_Api_Proto_CloudSignRequest_descriptor;
   private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_Diadoc_Api_Proto_CloudSignRequest_fieldAccessorTable;
+  com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internal_static_Diadoc_Api_Proto_CloudSignRequest_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_Diadoc_Api_Proto_CloudSignFile_descriptor;
+          internal_static_Diadoc_Api_Proto_CloudSignFile_descriptor;
   private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_Diadoc_Api_Proto_CloudSignFile_fieldAccessorTable;
+  com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internal_static_Diadoc_Api_Proto_CloudSignFile_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_Diadoc_Api_Proto_CloudSignResult_descriptor;
+          internal_static_Diadoc_Api_Proto_CloudSignResult_descriptor;
   private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_Diadoc_Api_Proto_CloudSignResult_fieldAccessorTable;
+  com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internal_static_Diadoc_Api_Proto_CloudSignResult_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_descriptor;
+          internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_descriptor;
   private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_fieldAccessorTable;
+  com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_descriptor;
+          internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_descriptor;
   private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_fieldAccessorTable;
+  com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
-      getDescriptor() {
+  getDescriptor() {
     return descriptor;
   }
   private static com.google.protobuf.Descriptors.FileDescriptor
-      descriptor;
+          descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\017CloudSign.proto\022\020Diadoc.Api.Proto\032\020Con" +
-      "tent_v2.proto\"B\n\020CloudSignRequest\022.\n\005Fil" +
-      "es\030\001 \003(\0132\037.Diadoc.Api.Proto.CloudSignFil" +
-      "e\"P\n\rCloudSignFile\022-\n\007Content\030\001 \001(\0132\034.Di" +
-      "adoc.Api.Proto.Content_v2\022\020\n\010FileName\030\002 " +
-      "\001(\t\" \n\017CloudSignResult\022\r\n\005Token\030\001 \001(\t\"J\n" +
-      "\026CloudSignConfirmResult\0220\n\nSignatures\030\001 " +
-      "\003(\0132\034.Diadoc.Api.Proto.Content_v2\"K\n\026Aut" +
-      "osignReceiptsResult\022\033\n\023SignedReceiptsCou" +
-      "nt\030\001 \002(\003\022\024\n\014NextBatchKey\030\002 \002(\tB\021B\017CloudS",
-      "ignProtos"
+            "\n\017CloudSign.proto\022\020Diadoc.Api.Proto\032\020Con" +
+                    "tent_v2.proto\"F\n\020CloudSignRequest\0222\n\005Fil" +
+                    "es\030\001 \003(\0132\037.Diadoc.Api.Proto.CloudSignFil" +
+                    "eB\002\030\001\"X\n\rCloudSignFile\0221\n\007Content\030\001 \001(\0132" +
+                    "\034.Diadoc.Api.Proto.Content_v2B\002\030\001\022\024\n\010Fil" +
+                    "eName\030\002 \001(\tB\002\030\001\"$\n\017CloudSignResult\022\021\n\005To" +
+                    "ken\030\001 \001(\tB\002\030\001\"N\n\026CloudSignConfirmResult\022" +
+                    "4\n\nSignatures\030\001 \003(\0132\034.Diadoc.Api.Proto.C" +
+                    "ontent_v2B\002\030\001\"S\n\026AutosignReceiptsResult\022" +
+                    "\037\n\023SignedReceiptsCount\030\001 \002(\003B\002\030\001\022\030\n\014Next",
+            "BatchKey\030\002 \002(\tB\002\030\001B\021B\017CloudSignProtos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-          public com.google.protobuf.ExtensionRegistry assignDescriptors(
-              com.google.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
-            return null;
-          }
-        };
+            new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
+              public com.google.protobuf.ExtensionRegistry assignDescriptors(
+                      com.google.protobuf.Descriptors.FileDescriptor root) {
+                descriptor = root;
+                return null;
+              }
+            };
     com.google.protobuf.Descriptors.FileDescriptor
-      .internalBuildGeneratedFileFrom(descriptorData,
-        new com.google.protobuf.Descriptors.FileDescriptor[] {
-          Diadoc.Api.Proto.Content_v2Protos.getDescriptor(),
-        }, assigner);
+            .internalBuildGeneratedFileFrom(descriptorData,
+                    new com.google.protobuf.Descriptors.FileDescriptor[] {
+                            Diadoc.Api.Proto.Content_v2Protos.getDescriptor(),
+                    }, assigner);
     internal_static_Diadoc_Api_Proto_CloudSignRequest_descriptor =
-      getDescriptor().getMessageTypes().get(0);
+            getDescriptor().getMessageTypes().get(0);
     internal_static_Diadoc_Api_Proto_CloudSignRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_Diadoc_Api_Proto_CloudSignRequest_descriptor,
-        new java.lang.String[] { "Files", });
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+            internal_static_Diadoc_Api_Proto_CloudSignRequest_descriptor,
+            new java.lang.String[] { "Files", });
     internal_static_Diadoc_Api_Proto_CloudSignFile_descriptor =
-      getDescriptor().getMessageTypes().get(1);
+            getDescriptor().getMessageTypes().get(1);
     internal_static_Diadoc_Api_Proto_CloudSignFile_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_Diadoc_Api_Proto_CloudSignFile_descriptor,
-        new java.lang.String[] { "Content", "FileName", });
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+            internal_static_Diadoc_Api_Proto_CloudSignFile_descriptor,
+            new java.lang.String[] { "Content", "FileName", });
     internal_static_Diadoc_Api_Proto_CloudSignResult_descriptor =
-      getDescriptor().getMessageTypes().get(2);
+            getDescriptor().getMessageTypes().get(2);
     internal_static_Diadoc_Api_Proto_CloudSignResult_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_Diadoc_Api_Proto_CloudSignResult_descriptor,
-        new java.lang.String[] { "Token", });
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+            internal_static_Diadoc_Api_Proto_CloudSignResult_descriptor,
+            new java.lang.String[] { "Token", });
     internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_descriptor =
-      getDescriptor().getMessageTypes().get(3);
+            getDescriptor().getMessageTypes().get(3);
     internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_descriptor,
-        new java.lang.String[] { "Signatures", });
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+            internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_descriptor,
+            new java.lang.String[] { "Signatures", });
     internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_descriptor =
-      getDescriptor().getMessageTypes().get(4);
+            getDescriptor().getMessageTypes().get(4);
     internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_descriptor,
-        new java.lang.String[] { "SignedReceiptsCount", "NextBatchKey", });
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+            internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_descriptor,
+            new java.lang.String[] { "SignedReceiptsCount", "NextBatchKey", });
     Diadoc.Api.Proto.Content_v2Protos.getDescriptor();
   }
 

--- a/src/main/java/Diadoc/Api/Proto/CloudSignProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/CloudSignProtos.java
@@ -3,24 +3,21 @@
 
 package Diadoc.Api.Proto;
 
-/**
- * @deprecated Этот класс устарел и будет удалён в следующей мажорной версии.
- */
-@Deprecated
 public final class CloudSignProtos {
   private CloudSignProtos() {}
   public static void registerAllExtensions(
-          com.google.protobuf.ExtensionRegistry registry) {
+      com.google.protobuf.ExtensionRegistry registry) {
+    registry.add(Diadoc.Api.Proto.CloudSignProtos.fileDeprecated);
   }
   public interface CloudSignRequestOrBuilder extends
-          // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.CloudSignRequest)
-          com.google.protobuf.MessageOrBuilder {
+      // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.CloudSignRequest)
+      com.google.protobuf.MessageOrBuilder {
 
     /**
      * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
      */
-    @java.lang.Deprecated java.util.List<Diadoc.Api.Proto.CloudSignProtos.CloudSignFile>
-    getFilesList();
+    @java.lang.Deprecated java.util.List<Diadoc.Api.Proto.CloudSignProtos.CloudSignFile> 
+        getFilesList();
     /**
      * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
      */
@@ -32,21 +29,21 @@ public final class CloudSignProtos {
     /**
      * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
      */
-    @java.lang.Deprecated java.util.List<? extends Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder>
-    getFilesOrBuilderList();
+    @java.lang.Deprecated java.util.List<? extends Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder> 
+        getFilesOrBuilderList();
     /**
      * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder getFilesOrBuilder(
-            int index);
+        int index);
   }
   /**
    * Protobuf type {@code Diadoc.Api.Proto.CloudSignRequest}
    */
   public static final class CloudSignRequest extends
-          com.google.protobuf.GeneratedMessage implements
-          // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.CloudSignRequest)
-          CloudSignRequestOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.CloudSignRequest)
+      CloudSignRequestOrBuilder {
     // Use CloudSignRequest.newBuilder() to construct.
     private CloudSignRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -66,17 +63,17 @@ public final class CloudSignProtos {
     private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
+        getUnknownFields() {
       return this.unknownFields;
     }
     private CloudSignRequest(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       initFields();
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-              com.google.protobuf.UnknownFieldSet.newBuilder();
+          com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -87,7 +84,7 @@ public final class CloudSignProtos {
               break;
             default: {
               if (!parseUnknownField(input, unknownFields,
-                      extensionRegistry, tag)) {
+                                     extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -106,7 +103,7 @@ public final class CloudSignProtos {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-                e.getMessage()).setUnfinishedMessage(this);
+            e.getMessage()).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
           files_ = java.util.Collections.unmodifiableList(files_);
@@ -116,26 +113,26 @@ public final class CloudSignProtos {
       }
     }
     public static final com.google.protobuf.Descriptors.Descriptor
-    getDescriptor() {
+        getDescriptor() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignRequest_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-    internalGetFieldAccessorTable() {
+        internalGetFieldAccessorTable() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignRequest_fieldAccessorTable
-              .ensureFieldAccessorsInitialized(
-                      Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest.Builder.class);
+          .ensureFieldAccessorsInitialized(
+              Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest.Builder.class);
     }
 
     public static com.google.protobuf.Parser<CloudSignRequest> PARSER =
-            new com.google.protobuf.AbstractParser<CloudSignRequest>() {
-              public CloudSignRequest parsePartialFrom(
-                      com.google.protobuf.CodedInputStream input,
-                      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                      throws com.google.protobuf.InvalidProtocolBufferException {
-                return new CloudSignRequest(input, extensionRegistry);
-              }
-            };
+        new com.google.protobuf.AbstractParser<CloudSignRequest>() {
+      public CloudSignRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new CloudSignRequest(input, extensionRegistry);
+      }
+    };
 
     @java.lang.Override
     public com.google.protobuf.Parser<CloudSignRequest> getParserForType() {
@@ -153,8 +150,8 @@ public final class CloudSignProtos {
     /**
      * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
      */
-    @java.lang.Deprecated public java.util.List<? extends Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder>
-    getFilesOrBuilderList() {
+    @java.lang.Deprecated public java.util.List<? extends Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder> 
+        getFilesOrBuilderList() {
       return files_;
     }
     /**
@@ -173,7 +170,7 @@ public final class CloudSignProtos {
      * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder getFilesOrBuilder(
-            int index) {
+        int index) {
       return files_.get(index);
     }
 
@@ -197,7 +194,7 @@ public final class CloudSignProtos {
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
-            throws java.io.IOException {
+                        throws java.io.IOException {
       getSerializedSize();
       for (int i = 0; i < files_.size(); i++) {
         output.writeMessage(1, files_.get(i));
@@ -213,7 +210,7 @@ public final class CloudSignProtos {
       size = 0;
       for (int i = 0; i < files_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
-                .computeMessageSize(1, files_.get(i));
+          .computeMessageSize(1, files_.get(i));
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -223,60 +220,60 @@ public final class CloudSignProtos {
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
-            throws java.io.ObjectStreamException {
+        throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
 
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseFrom(
-            com.google.protobuf.ByteString data)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseFrom(
-            com.google.protobuf.ByteString data,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseFrom(byte[] data)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseFrom(
-            byte[] data,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseFrom(java.io.InputStream input)
-            throws java.io.IOException {
+        throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseFrom(
-            java.io.InputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseDelimitedFrom(java.io.InputStream input)
-            throws java.io.IOException {
+        throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseDelimitedFrom(
-            java.io.InputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseFrom(
-            com.google.protobuf.CodedInputStream input)
-            throws java.io.IOException {
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parseFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
 
@@ -289,7 +286,7 @@ public final class CloudSignProtos {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -297,19 +294,19 @@ public final class CloudSignProtos {
      * Protobuf type {@code Diadoc.Api.Proto.CloudSignRequest}
      */
     public static final class Builder extends
-            com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-            // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.CloudSignRequest)
-            Diadoc.Api.Proto.CloudSignProtos.CloudSignRequestOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.CloudSignRequest)
+        Diadoc.Api.Proto.CloudSignProtos.CloudSignRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
+          getDescriptor() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignRequest_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internalGetFieldAccessorTable() {
+          internalGetFieldAccessorTable() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignRequest_fieldAccessorTable
-                .ensureFieldAccessorsInitialized(
-                        Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest.Builder.class);
+            .ensureFieldAccessorsInitialized(
+                Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest.Builder.class);
       }
 
       // Construct using Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest.newBuilder()
@@ -318,7 +315,7 @@ public final class CloudSignProtos {
       }
 
       private Builder(
-              com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -347,7 +344,7 @@ public final class CloudSignProtos {
       }
 
       public com.google.protobuf.Descriptors.Descriptor
-      getDescriptorForType() {
+          getDescriptorForType() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignRequest_descriptor;
       }
 
@@ -408,9 +405,9 @@ public final class CloudSignProtos {
               filesBuilder_ = null;
               files_ = other.files_;
               bitField0_ = (bitField0_ & ~0x00000001);
-              filesBuilder_ =
-                      com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                              getFilesFieldBuilder() : null;
+              filesBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getFilesFieldBuilder() : null;
             } else {
               filesBuilder_.addAllMessages(other.files_);
             }
@@ -423,7 +420,7 @@ public final class CloudSignProtos {
       public final boolean isInitialized() {
         for (int i = 0; i < getFilesCount(); i++) {
           if (!getFiles(i).isInitialized()) {
-
+            
             return false;
           }
         }
@@ -431,9 +428,9 @@ public final class CloudSignProtos {
       }
 
       public Builder mergeFrom(
-              com.google.protobuf.CodedInputStream input,
-              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws java.io.IOException {
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
         Diadoc.Api.Proto.CloudSignProtos.CloudSignRequest parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
@@ -450,16 +447,16 @@ public final class CloudSignProtos {
       private int bitField0_;
 
       private java.util.List<Diadoc.Api.Proto.CloudSignProtos.CloudSignFile> files_ =
-              java.util.Collections.emptyList();
+        java.util.Collections.emptyList();
       private void ensureFilesIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
           files_ = new java.util.ArrayList<Diadoc.Api.Proto.CloudSignProtos.CloudSignFile>(files_);
           bitField0_ |= 0x00000001;
-        }
+         }
       }
 
       private com.google.protobuf.RepeatedFieldBuilder<
-              Diadoc.Api.Proto.CloudSignProtos.CloudSignFile, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder, Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder> filesBuilder_;
+          Diadoc.Api.Proto.CloudSignProtos.CloudSignFile, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder, Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder> filesBuilder_;
 
       /**
        * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
@@ -495,7 +492,7 @@ public final class CloudSignProtos {
        * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Builder setFiles(
-              int index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile value) {
+          int index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile value) {
         if (filesBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -512,7 +509,7 @@ public final class CloudSignProtos {
        * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Builder setFiles(
-              int index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder builderForValue) {
+          int index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder builderForValue) {
         if (filesBuilder_ == null) {
           ensureFilesIsMutable();
           files_.set(index, builderForValue.build());
@@ -542,7 +539,7 @@ public final class CloudSignProtos {
        * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Builder addFiles(
-              int index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile value) {
+          int index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile value) {
         if (filesBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -559,7 +556,7 @@ public final class CloudSignProtos {
        * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Builder addFiles(
-              Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder builderForValue) {
+          Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder builderForValue) {
         if (filesBuilder_ == null) {
           ensureFilesIsMutable();
           files_.add(builderForValue.build());
@@ -573,7 +570,7 @@ public final class CloudSignProtos {
        * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Builder addFiles(
-              int index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder builderForValue) {
+          int index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder builderForValue) {
         if (filesBuilder_ == null) {
           ensureFilesIsMutable();
           files_.add(index, builderForValue.build());
@@ -587,11 +584,11 @@ public final class CloudSignProtos {
        * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Builder addAllFiles(
-              java.lang.Iterable<? extends Diadoc.Api.Proto.CloudSignProtos.CloudSignFile> values) {
+          java.lang.Iterable<? extends Diadoc.Api.Proto.CloudSignProtos.CloudSignFile> values) {
         if (filesBuilder_ == null) {
           ensureFilesIsMutable();
           com.google.protobuf.AbstractMessageLite.Builder.addAll(
-                  values, files_);
+              values, files_);
           onChanged();
         } else {
           filesBuilder_.addAllMessages(values);
@@ -628,14 +625,14 @@ public final class CloudSignProtos {
        * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder getFilesBuilder(
-              int index) {
+          int index) {
         return getFilesFieldBuilder().getBuilder(index);
       }
       /**
        * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder getFilesOrBuilder(
-              int index) {
+          int index) {
         if (filesBuilder_ == null) {
           return files_.get(index);  } else {
           return filesBuilder_.getMessageOrBuilder(index);
@@ -644,8 +641,8 @@ public final class CloudSignProtos {
       /**
        * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      @java.lang.Deprecated public java.util.List<? extends Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder>
-      getFilesOrBuilderList() {
+      @java.lang.Deprecated public java.util.List<? extends Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder> 
+           getFilesOrBuilderList() {
         if (filesBuilder_ != null) {
           return filesBuilder_.getMessageOrBuilderList();
         } else {
@@ -657,29 +654,29 @@ public final class CloudSignProtos {
        */
       @java.lang.Deprecated public Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder addFilesBuilder() {
         return getFilesFieldBuilder().addBuilder(
-                Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.getDefaultInstance());
+            Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.getDefaultInstance());
       }
       /**
        * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder addFilesBuilder(
-              int index) {
+          int index) {
         return getFilesFieldBuilder().addBuilder(
-                index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.getDefaultInstance());
+            index, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.getDefaultInstance());
       }
       /**
        * <code>repeated .Diadoc.Api.Proto.CloudSignFile Files = 1 [deprecated = true];</code>
        */
-      @java.lang.Deprecated public java.util.List<Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder>
-      getFilesBuilderList() {
+      @java.lang.Deprecated public java.util.List<Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder> 
+           getFilesBuilderList() {
         return getFilesFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilder<
-              Diadoc.Api.Proto.CloudSignProtos.CloudSignFile, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder, Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder>
-      getFilesFieldBuilder() {
+          Diadoc.Api.Proto.CloudSignProtos.CloudSignFile, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder, Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder> 
+          getFilesFieldBuilder() {
         if (filesBuilder_ == null) {
           filesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-                  Diadoc.Api.Proto.CloudSignProtos.CloudSignFile, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder, Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder>(
+              Diadoc.Api.Proto.CloudSignProtos.CloudSignFile, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder, Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder>(
                   files_,
                   ((bitField0_ & 0x00000001) == 0x00000001),
                   getParentForChildren(),
@@ -701,8 +698,8 @@ public final class CloudSignProtos {
   }
 
   public interface CloudSignFileOrBuilder extends
-          // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.CloudSignFile)
-          com.google.protobuf.MessageOrBuilder {
+      // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.CloudSignFile)
+      com.google.protobuf.MessageOrBuilder {
 
     /**
      * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1 [deprecated = true];</code>
@@ -729,15 +726,24 @@ public final class CloudSignProtos {
      * <code>optional string FileName = 2 [deprecated = true];</code>
      */
     @java.lang.Deprecated com.google.protobuf.ByteString
-    getFileNameBytes();
+        getFileNameBytes();
+
+    /**
+     * <code>optional bool deprecated = 3 [default = true];</code>
+     */
+    boolean hasDeprecated();
+    /**
+     * <code>optional bool deprecated = 3 [default = true];</code>
+     */
+    boolean getDeprecated();
   }
   /**
    * Protobuf type {@code Diadoc.Api.Proto.CloudSignFile}
    */
   public static final class CloudSignFile extends
-          com.google.protobuf.GeneratedMessage implements
-          // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.CloudSignFile)
-          CloudSignFileOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.CloudSignFile)
+      CloudSignFileOrBuilder {
     // Use CloudSignFile.newBuilder() to construct.
     private CloudSignFile(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -757,17 +763,17 @@ public final class CloudSignProtos {
     private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
+        getUnknownFields() {
       return this.unknownFields;
     }
     private CloudSignFile(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       initFields();
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-              com.google.protobuf.UnknownFieldSet.newBuilder();
+          com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -778,7 +784,7 @@ public final class CloudSignProtos {
               break;
             default: {
               if (!parseUnknownField(input, unknownFields,
-                      extensionRegistry, tag)) {
+                                     extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -802,39 +808,44 @@ public final class CloudSignProtos {
               fileName_ = bs;
               break;
             }
+            case 24: {
+              bitField0_ |= 0x00000004;
+              deprecated_ = input.readBool();
+              break;
+            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-                e.getMessage()).setUnfinishedMessage(this);
+            e.getMessage()).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
     }
     public static final com.google.protobuf.Descriptors.Descriptor
-    getDescriptor() {
+        getDescriptor() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignFile_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-    internalGetFieldAccessorTable() {
+        internalGetFieldAccessorTable() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignFile_fieldAccessorTable
-              .ensureFieldAccessorsInitialized(
-                      Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder.class);
+          .ensureFieldAccessorsInitialized(
+              Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder.class);
     }
 
     public static com.google.protobuf.Parser<CloudSignFile> PARSER =
-            new com.google.protobuf.AbstractParser<CloudSignFile>() {
-              public CloudSignFile parsePartialFrom(
-                      com.google.protobuf.CodedInputStream input,
-                      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                      throws com.google.protobuf.InvalidProtocolBufferException {
-                return new CloudSignFile(input, extensionRegistry);
-              }
-            };
+        new com.google.protobuf.AbstractParser<CloudSignFile>() {
+      public CloudSignFile parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new CloudSignFile(input, extensionRegistry);
+      }
+    };
 
     @java.lang.Override
     public com.google.protobuf.Parser<CloudSignFile> getParserForType() {
@@ -879,8 +890,8 @@ public final class CloudSignProtos {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
-                (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           fileName_ = s;
@@ -892,12 +903,12 @@ public final class CloudSignProtos {
      * <code>optional string FileName = 2 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.google.protobuf.ByteString
-    getFileNameBytes() {
+        getFileNameBytes() {
       java.lang.Object ref = fileName_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
-                com.google.protobuf.ByteString.copyFromUtf8(
-                        (java.lang.String) ref);
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
         fileName_ = b;
         return b;
       } else {
@@ -905,9 +916,25 @@ public final class CloudSignProtos {
       }
     }
 
+    public static final int DEPRECATED_FIELD_NUMBER = 3;
+    private boolean deprecated_;
+    /**
+     * <code>optional bool deprecated = 3 [default = true];</code>
+     */
+    public boolean hasDeprecated() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>optional bool deprecated = 3 [default = true];</code>
+     */
+    public boolean getDeprecated() {
+      return deprecated_;
+    }
+
     private void initFields() {
       content_ = Diadoc.Api.Proto.Content_v2Protos.Content_v2.getDefaultInstance();
       fileName_ = "";
+      deprecated_ = true;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -926,13 +953,16 @@ public final class CloudSignProtos {
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
-            throws java.io.IOException {
+                        throws java.io.IOException {
       getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeMessage(1, content_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeBytes(2, getFileNameBytes());
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeBool(3, deprecated_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -945,11 +975,15 @@ public final class CloudSignProtos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-                .computeMessageSize(1, content_);
+          .computeMessageSize(1, content_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-                .computeBytesSize(2, getFileNameBytes());
+          .computeBytesSize(2, getFileNameBytes());
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(3, deprecated_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -959,60 +993,60 @@ public final class CloudSignProtos {
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
-            throws java.io.ObjectStreamException {
+        throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
 
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseFrom(
-            com.google.protobuf.ByteString data)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseFrom(
-            com.google.protobuf.ByteString data,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseFrom(byte[] data)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseFrom(
-            byte[] data,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseFrom(java.io.InputStream input)
-            throws java.io.IOException {
+        throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseFrom(
-            java.io.InputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseDelimitedFrom(java.io.InputStream input)
-            throws java.io.IOException {
+        throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseDelimitedFrom(
-            java.io.InputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseFrom(
-            com.google.protobuf.CodedInputStream input)
-            throws java.io.IOException {
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parseFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
 
@@ -1025,7 +1059,7 @@ public final class CloudSignProtos {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -1033,19 +1067,19 @@ public final class CloudSignProtos {
      * Protobuf type {@code Diadoc.Api.Proto.CloudSignFile}
      */
     public static final class Builder extends
-            com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-            // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.CloudSignFile)
-            Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.CloudSignFile)
+        Diadoc.Api.Proto.CloudSignProtos.CloudSignFileOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
+          getDescriptor() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignFile_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internalGetFieldAccessorTable() {
+          internalGetFieldAccessorTable() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignFile_fieldAccessorTable
-                .ensureFieldAccessorsInitialized(
-                        Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder.class);
+            .ensureFieldAccessorsInitialized(
+                Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.Builder.class);
       }
 
       // Construct using Diadoc.Api.Proto.CloudSignProtos.CloudSignFile.newBuilder()
@@ -1054,7 +1088,7 @@ public final class CloudSignProtos {
       }
 
       private Builder(
-              com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -1077,6 +1111,8 @@ public final class CloudSignProtos {
         bitField0_ = (bitField0_ & ~0x00000001);
         fileName_ = "";
         bitField0_ = (bitField0_ & ~0x00000002);
+        deprecated_ = true;
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
@@ -1085,7 +1121,7 @@ public final class CloudSignProtos {
       }
 
       public com.google.protobuf.Descriptors.Descriptor
-      getDescriptorForType() {
+          getDescriptorForType() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignFile_descriptor;
       }
 
@@ -1117,6 +1153,10 @@ public final class CloudSignProtos {
           to_bitField0_ |= 0x00000002;
         }
         result.fileName_ = fileName_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.deprecated_ = deprecated_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -1141,6 +1181,9 @@ public final class CloudSignProtos {
           fileName_ = other.fileName_;
           onChanged();
         }
+        if (other.hasDeprecated()) {
+          setDeprecated(other.getDeprecated());
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
@@ -1148,7 +1191,7 @@ public final class CloudSignProtos {
       public final boolean isInitialized() {
         if (hasContent()) {
           if (!getContent().isInitialized()) {
-
+            
             return false;
           }
         }
@@ -1156,9 +1199,9 @@ public final class CloudSignProtos {
       }
 
       public Builder mergeFrom(
-              com.google.protobuf.CodedInputStream input,
-              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws java.io.IOException {
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
         Diadoc.Api.Proto.CloudSignProtos.CloudSignFile parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
@@ -1176,7 +1219,7 @@ public final class CloudSignProtos {
 
       private Diadoc.Api.Proto.Content_v2Protos.Content_v2 content_ = Diadoc.Api.Proto.Content_v2Protos.Content_v2.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
-              Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder> contentBuilder_;
+          Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder> contentBuilder_;
       /**
        * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1 [deprecated = true];</code>
        */
@@ -1213,7 +1256,7 @@ public final class CloudSignProtos {
        * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Builder setContent(
-              Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder builderForValue) {
+          Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder builderForValue) {
         if (contentBuilder_ == null) {
           content_ = builderForValue.build();
           onChanged();
@@ -1229,9 +1272,9 @@ public final class CloudSignProtos {
       @java.lang.Deprecated public Builder mergeContent(Diadoc.Api.Proto.Content_v2Protos.Content_v2 value) {
         if (contentBuilder_ == null) {
           if (((bitField0_ & 0x00000001) == 0x00000001) &&
-                  content_ != Diadoc.Api.Proto.Content_v2Protos.Content_v2.getDefaultInstance()) {
+              content_ != Diadoc.Api.Proto.Content_v2Protos.Content_v2.getDefaultInstance()) {
             content_ =
-                    Diadoc.Api.Proto.Content_v2Protos.Content_v2.newBuilder(content_).mergeFrom(value).buildPartial();
+              Diadoc.Api.Proto.Content_v2Protos.Content_v2.newBuilder(content_).mergeFrom(value).buildPartial();
           } else {
             content_ = value;
           }
@@ -1277,11 +1320,11 @@ public final class CloudSignProtos {
        * <code>optional .Diadoc.Api.Proto.Content_v2 Content = 1 [deprecated = true];</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
-              Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder>
-      getContentFieldBuilder() {
+          Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder> 
+          getContentFieldBuilder() {
         if (contentBuilder_ == null) {
           contentBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-                  Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder>(
+              Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder>(
                   getContent(),
                   getParentForChildren(),
                   isClean());
@@ -1304,7 +1347,7 @@ public final class CloudSignProtos {
         java.lang.Object ref = fileName_;
         if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
-                  (com.google.protobuf.ByteString) ref;
+              (com.google.protobuf.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             fileName_ = s;
@@ -1318,12 +1361,12 @@ public final class CloudSignProtos {
        * <code>optional string FileName = 2 [deprecated = true];</code>
        */
       @java.lang.Deprecated public com.google.protobuf.ByteString
-      getFileNameBytes() {
+          getFileNameBytes() {
         java.lang.Object ref = fileName_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
-                  com.google.protobuf.ByteString.copyFromUtf8(
-                          (java.lang.String) ref);
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
           fileName_ = b;
           return b;
         } else {
@@ -1334,11 +1377,11 @@ public final class CloudSignProtos {
        * <code>optional string FileName = 2 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Builder setFileName(
-              java.lang.String value) {
+          java.lang.String value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000002;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
         fileName_ = value;
         onChanged();
         return this;
@@ -1356,12 +1399,44 @@ public final class CloudSignProtos {
        * <code>optional string FileName = 2 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Builder setFileNameBytes(
-              com.google.protobuf.ByteString value) {
+          com.google.protobuf.ByteString value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000002;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
         fileName_ = value;
+        onChanged();
+        return this;
+      }
+
+      private boolean deprecated_ = true;
+      /**
+       * <code>optional bool deprecated = 3 [default = true];</code>
+       */
+      public boolean hasDeprecated() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>optional bool deprecated = 3 [default = true];</code>
+       */
+      public boolean getDeprecated() {
+        return deprecated_;
+      }
+      /**
+       * <code>optional bool deprecated = 3 [default = true];</code>
+       */
+      public Builder setDeprecated(boolean value) {
+        bitField0_ |= 0x00000004;
+        deprecated_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool deprecated = 3 [default = true];</code>
+       */
+      public Builder clearDeprecated() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        deprecated_ = true;
         onChanged();
         return this;
       }
@@ -1378,8 +1453,8 @@ public final class CloudSignProtos {
   }
 
   public interface CloudSignResultOrBuilder extends
-          // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.CloudSignResult)
-          com.google.protobuf.MessageOrBuilder {
+      // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.CloudSignResult)
+      com.google.protobuf.MessageOrBuilder {
 
     /**
      * <code>optional string Token = 1 [deprecated = true];</code>
@@ -1393,15 +1468,15 @@ public final class CloudSignProtos {
      * <code>optional string Token = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated com.google.protobuf.ByteString
-    getTokenBytes();
+        getTokenBytes();
   }
   /**
    * Protobuf type {@code Diadoc.Api.Proto.CloudSignResult}
    */
   public static final class CloudSignResult extends
-          com.google.protobuf.GeneratedMessage implements
-          // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.CloudSignResult)
-          CloudSignResultOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.CloudSignResult)
+      CloudSignResultOrBuilder {
     // Use CloudSignResult.newBuilder() to construct.
     private CloudSignResult(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -1421,17 +1496,17 @@ public final class CloudSignProtos {
     private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
+        getUnknownFields() {
       return this.unknownFields;
     }
     private CloudSignResult(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       initFields();
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-              com.google.protobuf.UnknownFieldSet.newBuilder();
+          com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -1442,7 +1517,7 @@ public final class CloudSignProtos {
               break;
             default: {
               if (!parseUnknownField(input, unknownFields,
-                      extensionRegistry, tag)) {
+                                     extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -1459,33 +1534,33 @@ public final class CloudSignProtos {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-                e.getMessage()).setUnfinishedMessage(this);
+            e.getMessage()).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
     }
     public static final com.google.protobuf.Descriptors.Descriptor
-    getDescriptor() {
+        getDescriptor() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignResult_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-    internalGetFieldAccessorTable() {
+        internalGetFieldAccessorTable() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignResult_fieldAccessorTable
-              .ensureFieldAccessorsInitialized(
-                      Diadoc.Api.Proto.CloudSignProtos.CloudSignResult.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignResult.Builder.class);
+          .ensureFieldAccessorsInitialized(
+              Diadoc.Api.Proto.CloudSignProtos.CloudSignResult.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignResult.Builder.class);
     }
 
     public static com.google.protobuf.Parser<CloudSignResult> PARSER =
-            new com.google.protobuf.AbstractParser<CloudSignResult>() {
-              public CloudSignResult parsePartialFrom(
-                      com.google.protobuf.CodedInputStream input,
-                      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                      throws com.google.protobuf.InvalidProtocolBufferException {
-                return new CloudSignResult(input, extensionRegistry);
-              }
-            };
+        new com.google.protobuf.AbstractParser<CloudSignResult>() {
+      public CloudSignResult parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new CloudSignResult(input, extensionRegistry);
+      }
+    };
 
     @java.lang.Override
     public com.google.protobuf.Parser<CloudSignResult> getParserForType() {
@@ -1509,8 +1584,8 @@ public final class CloudSignProtos {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
-                (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           token_ = s;
@@ -1522,12 +1597,12 @@ public final class CloudSignProtos {
      * <code>optional string Token = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.google.protobuf.ByteString
-    getTokenBytes() {
+        getTokenBytes() {
       java.lang.Object ref = token_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
-                com.google.protobuf.ByteString.copyFromUtf8(
-                        (java.lang.String) ref);
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
         token_ = b;
         return b;
       } else {
@@ -1549,7 +1624,7 @@ public final class CloudSignProtos {
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
-            throws java.io.IOException {
+                        throws java.io.IOException {
       getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeBytes(1, getTokenBytes());
@@ -1565,7 +1640,7 @@ public final class CloudSignProtos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-                .computeBytesSize(1, getTokenBytes());
+          .computeBytesSize(1, getTokenBytes());
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -1575,60 +1650,60 @@ public final class CloudSignProtos {
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
-            throws java.io.ObjectStreamException {
+        throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
 
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseFrom(
-            com.google.protobuf.ByteString data)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseFrom(
-            com.google.protobuf.ByteString data,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseFrom(byte[] data)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseFrom(
-            byte[] data,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseFrom(java.io.InputStream input)
-            throws java.io.IOException {
+        throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseFrom(
-            java.io.InputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseDelimitedFrom(java.io.InputStream input)
-            throws java.io.IOException {
+        throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseDelimitedFrom(
-            java.io.InputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseFrom(
-            com.google.protobuf.CodedInputStream input)
-            throws java.io.IOException {
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parseFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
 
@@ -1641,7 +1716,7 @@ public final class CloudSignProtos {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -1649,19 +1724,19 @@ public final class CloudSignProtos {
      * Protobuf type {@code Diadoc.Api.Proto.CloudSignResult}
      */
     public static final class Builder extends
-            com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-            // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.CloudSignResult)
-            Diadoc.Api.Proto.CloudSignProtos.CloudSignResultOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.CloudSignResult)
+        Diadoc.Api.Proto.CloudSignProtos.CloudSignResultOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
+          getDescriptor() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignResult_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internalGetFieldAccessorTable() {
+          internalGetFieldAccessorTable() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignResult_fieldAccessorTable
-                .ensureFieldAccessorsInitialized(
-                        Diadoc.Api.Proto.CloudSignProtos.CloudSignResult.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignResult.Builder.class);
+            .ensureFieldAccessorsInitialized(
+                Diadoc.Api.Proto.CloudSignProtos.CloudSignResult.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignResult.Builder.class);
       }
 
       // Construct using Diadoc.Api.Proto.CloudSignProtos.CloudSignResult.newBuilder()
@@ -1670,7 +1745,7 @@ public final class CloudSignProtos {
       }
 
       private Builder(
-              com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -1694,7 +1769,7 @@ public final class CloudSignProtos {
       }
 
       public com.google.protobuf.Descriptors.Descriptor
-      getDescriptorForType() {
+          getDescriptorForType() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignResult_descriptor;
       }
 
@@ -1748,9 +1823,9 @@ public final class CloudSignProtos {
       }
 
       public Builder mergeFrom(
-              com.google.protobuf.CodedInputStream input,
-              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws java.io.IOException {
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
         Diadoc.Api.Proto.CloudSignProtos.CloudSignResult parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
@@ -1780,7 +1855,7 @@ public final class CloudSignProtos {
         java.lang.Object ref = token_;
         if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
-                  (com.google.protobuf.ByteString) ref;
+              (com.google.protobuf.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             token_ = s;
@@ -1794,12 +1869,12 @@ public final class CloudSignProtos {
        * <code>optional string Token = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public com.google.protobuf.ByteString
-      getTokenBytes() {
+          getTokenBytes() {
         java.lang.Object ref = token_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
-                  com.google.protobuf.ByteString.copyFromUtf8(
-                          (java.lang.String) ref);
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
           token_ = b;
           return b;
         } else {
@@ -1810,11 +1885,11 @@ public final class CloudSignProtos {
        * <code>optional string Token = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Builder setToken(
-              java.lang.String value) {
+          java.lang.String value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000001;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
         token_ = value;
         onChanged();
         return this;
@@ -1832,11 +1907,11 @@ public final class CloudSignProtos {
        * <code>optional string Token = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Builder setTokenBytes(
-              com.google.protobuf.ByteString value) {
+          com.google.protobuf.ByteString value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000001;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
         token_ = value;
         onChanged();
         return this;
@@ -1854,14 +1929,14 @@ public final class CloudSignProtos {
   }
 
   public interface CloudSignConfirmResultOrBuilder extends
-          // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.CloudSignConfirmResult)
-          com.google.protobuf.MessageOrBuilder {
+      // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.CloudSignConfirmResult)
+      com.google.protobuf.MessageOrBuilder {
 
     /**
      * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
      */
-    @java.lang.Deprecated java.util.List<Diadoc.Api.Proto.Content_v2Protos.Content_v2>
-    getSignaturesList();
+    @java.lang.Deprecated java.util.List<Diadoc.Api.Proto.Content_v2Protos.Content_v2> 
+        getSignaturesList();
     /**
      * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
      */
@@ -1873,21 +1948,21 @@ public final class CloudSignProtos {
     /**
      * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
      */
-    @java.lang.Deprecated java.util.List<? extends Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder>
-    getSignaturesOrBuilderList();
+    @java.lang.Deprecated java.util.List<? extends Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder> 
+        getSignaturesOrBuilderList();
     /**
      * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder getSignaturesOrBuilder(
-            int index);
+        int index);
   }
   /**
    * Protobuf type {@code Diadoc.Api.Proto.CloudSignConfirmResult}
    */
   public static final class CloudSignConfirmResult extends
-          com.google.protobuf.GeneratedMessage implements
-          // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.CloudSignConfirmResult)
-          CloudSignConfirmResultOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.CloudSignConfirmResult)
+      CloudSignConfirmResultOrBuilder {
     // Use CloudSignConfirmResult.newBuilder() to construct.
     private CloudSignConfirmResult(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -1907,17 +1982,17 @@ public final class CloudSignProtos {
     private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
+        getUnknownFields() {
       return this.unknownFields;
     }
     private CloudSignConfirmResult(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       initFields();
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-              com.google.protobuf.UnknownFieldSet.newBuilder();
+          com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -1928,7 +2003,7 @@ public final class CloudSignProtos {
               break;
             default: {
               if (!parseUnknownField(input, unknownFields,
-                      extensionRegistry, tag)) {
+                                     extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -1947,7 +2022,7 @@ public final class CloudSignProtos {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-                e.getMessage()).setUnfinishedMessage(this);
+            e.getMessage()).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
           signatures_ = java.util.Collections.unmodifiableList(signatures_);
@@ -1957,26 +2032,26 @@ public final class CloudSignProtos {
       }
     }
     public static final com.google.protobuf.Descriptors.Descriptor
-    getDescriptor() {
+        getDescriptor() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-    internalGetFieldAccessorTable() {
+        internalGetFieldAccessorTable() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_fieldAccessorTable
-              .ensureFieldAccessorsInitialized(
-                      Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult.Builder.class);
+          .ensureFieldAccessorsInitialized(
+              Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult.Builder.class);
     }
 
     public static com.google.protobuf.Parser<CloudSignConfirmResult> PARSER =
-            new com.google.protobuf.AbstractParser<CloudSignConfirmResult>() {
-              public CloudSignConfirmResult parsePartialFrom(
-                      com.google.protobuf.CodedInputStream input,
-                      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                      throws com.google.protobuf.InvalidProtocolBufferException {
-                return new CloudSignConfirmResult(input, extensionRegistry);
-              }
-            };
+        new com.google.protobuf.AbstractParser<CloudSignConfirmResult>() {
+      public CloudSignConfirmResult parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new CloudSignConfirmResult(input, extensionRegistry);
+      }
+    };
 
     @java.lang.Override
     public com.google.protobuf.Parser<CloudSignConfirmResult> getParserForType() {
@@ -1994,8 +2069,8 @@ public final class CloudSignProtos {
     /**
      * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
      */
-    @java.lang.Deprecated public java.util.List<? extends Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder>
-    getSignaturesOrBuilderList() {
+    @java.lang.Deprecated public java.util.List<? extends Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder> 
+        getSignaturesOrBuilderList() {
       return signatures_;
     }
     /**
@@ -2014,7 +2089,7 @@ public final class CloudSignProtos {
      * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
      */
     @java.lang.Deprecated public Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder getSignaturesOrBuilder(
-            int index) {
+        int index) {
       return signatures_.get(index);
     }
 
@@ -2038,7 +2113,7 @@ public final class CloudSignProtos {
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
-            throws java.io.IOException {
+                        throws java.io.IOException {
       getSerializedSize();
       for (int i = 0; i < signatures_.size(); i++) {
         output.writeMessage(1, signatures_.get(i));
@@ -2054,7 +2129,7 @@ public final class CloudSignProtos {
       size = 0;
       for (int i = 0; i < signatures_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
-                .computeMessageSize(1, signatures_.get(i));
+          .computeMessageSize(1, signatures_.get(i));
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -2064,60 +2139,60 @@ public final class CloudSignProtos {
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
-            throws java.io.ObjectStreamException {
+        throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
 
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseFrom(
-            com.google.protobuf.ByteString data)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseFrom(
-            com.google.protobuf.ByteString data,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseFrom(byte[] data)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseFrom(
-            byte[] data,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseFrom(java.io.InputStream input)
-            throws java.io.IOException {
+        throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseFrom(
-            java.io.InputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseDelimitedFrom(java.io.InputStream input)
-            throws java.io.IOException {
+        throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseDelimitedFrom(
-            java.io.InputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseFrom(
-            com.google.protobuf.CodedInputStream input)
-            throws java.io.IOException {
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parseFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
 
@@ -2130,7 +2205,7 @@ public final class CloudSignProtos {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -2138,19 +2213,19 @@ public final class CloudSignProtos {
      * Protobuf type {@code Diadoc.Api.Proto.CloudSignConfirmResult}
      */
     public static final class Builder extends
-            com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-            // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.CloudSignConfirmResult)
-            Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResultOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.CloudSignConfirmResult)
+        Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResultOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
+          getDescriptor() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internalGetFieldAccessorTable() {
+          internalGetFieldAccessorTable() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_fieldAccessorTable
-                .ensureFieldAccessorsInitialized(
-                        Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult.Builder.class);
+            .ensureFieldAccessorsInitialized(
+                Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult.class, Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult.Builder.class);
       }
 
       // Construct using Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult.newBuilder()
@@ -2159,7 +2234,7 @@ public final class CloudSignProtos {
       }
 
       private Builder(
-              com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -2188,7 +2263,7 @@ public final class CloudSignProtos {
       }
 
       public com.google.protobuf.Descriptors.Descriptor
-      getDescriptorForType() {
+          getDescriptorForType() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_descriptor;
       }
 
@@ -2249,9 +2324,9 @@ public final class CloudSignProtos {
               signaturesBuilder_ = null;
               signatures_ = other.signatures_;
               bitField0_ = (bitField0_ & ~0x00000001);
-              signaturesBuilder_ =
-                      com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                              getSignaturesFieldBuilder() : null;
+              signaturesBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getSignaturesFieldBuilder() : null;
             } else {
               signaturesBuilder_.addAllMessages(other.signatures_);
             }
@@ -2264,7 +2339,7 @@ public final class CloudSignProtos {
       public final boolean isInitialized() {
         for (int i = 0; i < getSignaturesCount(); i++) {
           if (!getSignatures(i).isInitialized()) {
-
+            
             return false;
           }
         }
@@ -2272,9 +2347,9 @@ public final class CloudSignProtos {
       }
 
       public Builder mergeFrom(
-              com.google.protobuf.CodedInputStream input,
-              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws java.io.IOException {
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
         Diadoc.Api.Proto.CloudSignProtos.CloudSignConfirmResult parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
@@ -2291,16 +2366,16 @@ public final class CloudSignProtos {
       private int bitField0_;
 
       private java.util.List<Diadoc.Api.Proto.Content_v2Protos.Content_v2> signatures_ =
-              java.util.Collections.emptyList();
+        java.util.Collections.emptyList();
       private void ensureSignaturesIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
           signatures_ = new java.util.ArrayList<Diadoc.Api.Proto.Content_v2Protos.Content_v2>(signatures_);
           bitField0_ |= 0x00000001;
-        }
+         }
       }
 
       private com.google.protobuf.RepeatedFieldBuilder<
-              Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder> signaturesBuilder_;
+          Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder> signaturesBuilder_;
 
       /**
        * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
@@ -2336,7 +2411,7 @@ public final class CloudSignProtos {
        * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Builder setSignatures(
-              int index, Diadoc.Api.Proto.Content_v2Protos.Content_v2 value) {
+          int index, Diadoc.Api.Proto.Content_v2Protos.Content_v2 value) {
         if (signaturesBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -2353,7 +2428,7 @@ public final class CloudSignProtos {
        * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Builder setSignatures(
-              int index, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder builderForValue) {
+          int index, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder builderForValue) {
         if (signaturesBuilder_ == null) {
           ensureSignaturesIsMutable();
           signatures_.set(index, builderForValue.build());
@@ -2383,7 +2458,7 @@ public final class CloudSignProtos {
        * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Builder addSignatures(
-              int index, Diadoc.Api.Proto.Content_v2Protos.Content_v2 value) {
+          int index, Diadoc.Api.Proto.Content_v2Protos.Content_v2 value) {
         if (signaturesBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -2400,7 +2475,7 @@ public final class CloudSignProtos {
        * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Builder addSignatures(
-              Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder builderForValue) {
+          Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder builderForValue) {
         if (signaturesBuilder_ == null) {
           ensureSignaturesIsMutable();
           signatures_.add(builderForValue.build());
@@ -2414,7 +2489,7 @@ public final class CloudSignProtos {
        * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Builder addSignatures(
-              int index, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder builderForValue) {
+          int index, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder builderForValue) {
         if (signaturesBuilder_ == null) {
           ensureSignaturesIsMutable();
           signatures_.add(index, builderForValue.build());
@@ -2428,11 +2503,11 @@ public final class CloudSignProtos {
        * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Builder addAllSignatures(
-              java.lang.Iterable<? extends Diadoc.Api.Proto.Content_v2Protos.Content_v2> values) {
+          java.lang.Iterable<? extends Diadoc.Api.Proto.Content_v2Protos.Content_v2> values) {
         if (signaturesBuilder_ == null) {
           ensureSignaturesIsMutable();
           com.google.protobuf.AbstractMessageLite.Builder.addAll(
-                  values, signatures_);
+              values, signatures_);
           onChanged();
         } else {
           signaturesBuilder_.addAllMessages(values);
@@ -2469,14 +2544,14 @@ public final class CloudSignProtos {
        * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder getSignaturesBuilder(
-              int index) {
+          int index) {
         return getSignaturesFieldBuilder().getBuilder(index);
       }
       /**
        * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder getSignaturesOrBuilder(
-              int index) {
+          int index) {
         if (signaturesBuilder_ == null) {
           return signatures_.get(index);  } else {
           return signaturesBuilder_.getMessageOrBuilder(index);
@@ -2485,8 +2560,8 @@ public final class CloudSignProtos {
       /**
        * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      @java.lang.Deprecated public java.util.List<? extends Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder>
-      getSignaturesOrBuilderList() {
+      @java.lang.Deprecated public java.util.List<? extends Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder> 
+           getSignaturesOrBuilderList() {
         if (signaturesBuilder_ != null) {
           return signaturesBuilder_.getMessageOrBuilderList();
         } else {
@@ -2498,29 +2573,29 @@ public final class CloudSignProtos {
        */
       @java.lang.Deprecated public Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder addSignaturesBuilder() {
         return getSignaturesFieldBuilder().addBuilder(
-                Diadoc.Api.Proto.Content_v2Protos.Content_v2.getDefaultInstance());
+            Diadoc.Api.Proto.Content_v2Protos.Content_v2.getDefaultInstance());
       }
       /**
        * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder addSignaturesBuilder(
-              int index) {
+          int index) {
         return getSignaturesFieldBuilder().addBuilder(
-                index, Diadoc.Api.Proto.Content_v2Protos.Content_v2.getDefaultInstance());
+            index, Diadoc.Api.Proto.Content_v2Protos.Content_v2.getDefaultInstance());
       }
       /**
        * <code>repeated .Diadoc.Api.Proto.Content_v2 Signatures = 1 [deprecated = true];</code>
        */
-      @java.lang.Deprecated public java.util.List<Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder>
-      getSignaturesBuilderList() {
+      @java.lang.Deprecated public java.util.List<Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder> 
+           getSignaturesBuilderList() {
         return getSignaturesFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilder<
-              Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder>
-      getSignaturesFieldBuilder() {
+          Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder> 
+          getSignaturesFieldBuilder() {
         if (signaturesBuilder_ == null) {
           signaturesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
-                  Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder>(
+              Diadoc.Api.Proto.Content_v2Protos.Content_v2, Diadoc.Api.Proto.Content_v2Protos.Content_v2.Builder, Diadoc.Api.Proto.Content_v2Protos.Content_v2OrBuilder>(
                   signatures_,
                   ((bitField0_ & 0x00000001) == 0x00000001),
                   getParentForChildren(),
@@ -2542,8 +2617,8 @@ public final class CloudSignProtos {
   }
 
   public interface AutosignReceiptsResultOrBuilder extends
-          // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.AutosignReceiptsResult)
-          com.google.protobuf.MessageOrBuilder {
+      // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.AutosignReceiptsResult)
+      com.google.protobuf.MessageOrBuilder {
 
     /**
      * <code>required int64 SignedReceiptsCount = 1 [deprecated = true];</code>
@@ -2566,15 +2641,15 @@ public final class CloudSignProtos {
      * <code>required string NextBatchKey = 2 [deprecated = true];</code>
      */
     @java.lang.Deprecated com.google.protobuf.ByteString
-    getNextBatchKeyBytes();
+        getNextBatchKeyBytes();
   }
   /**
    * Protobuf type {@code Diadoc.Api.Proto.AutosignReceiptsResult}
    */
   public static final class AutosignReceiptsResult extends
-          com.google.protobuf.GeneratedMessage implements
-          // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.AutosignReceiptsResult)
-          AutosignReceiptsResultOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.AutosignReceiptsResult)
+      AutosignReceiptsResultOrBuilder {
     // Use AutosignReceiptsResult.newBuilder() to construct.
     private AutosignReceiptsResult(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -2594,17 +2669,17 @@ public final class CloudSignProtos {
     private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
+        getUnknownFields() {
       return this.unknownFields;
     }
     private AutosignReceiptsResult(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       initFields();
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-              com.google.protobuf.UnknownFieldSet.newBuilder();
+          com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -2615,7 +2690,7 @@ public final class CloudSignProtos {
               break;
             default: {
               if (!parseUnknownField(input, unknownFields,
-                      extensionRegistry, tag)) {
+                                     extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -2637,33 +2712,33 @@ public final class CloudSignProtos {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-                e.getMessage()).setUnfinishedMessage(this);
+            e.getMessage()).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
     }
     public static final com.google.protobuf.Descriptors.Descriptor
-    getDescriptor() {
+        getDescriptor() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-    internalGetFieldAccessorTable() {
+        internalGetFieldAccessorTable() {
       return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_fieldAccessorTable
-              .ensureFieldAccessorsInitialized(
-                      Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult.class, Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult.Builder.class);
+          .ensureFieldAccessorsInitialized(
+              Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult.class, Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult.Builder.class);
     }
 
     public static com.google.protobuf.Parser<AutosignReceiptsResult> PARSER =
-            new com.google.protobuf.AbstractParser<AutosignReceiptsResult>() {
-              public AutosignReceiptsResult parsePartialFrom(
-                      com.google.protobuf.CodedInputStream input,
-                      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                      throws com.google.protobuf.InvalidProtocolBufferException {
-                return new AutosignReceiptsResult(input, extensionRegistry);
-              }
-            };
+        new com.google.protobuf.AbstractParser<AutosignReceiptsResult>() {
+      public AutosignReceiptsResult parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new AutosignReceiptsResult(input, extensionRegistry);
+      }
+    };
 
     @java.lang.Override
     public com.google.protobuf.Parser<AutosignReceiptsResult> getParserForType() {
@@ -2702,8 +2777,8 @@ public final class CloudSignProtos {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs =
-                (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           nextBatchKey_ = s;
@@ -2715,12 +2790,12 @@ public final class CloudSignProtos {
      * <code>required string NextBatchKey = 2 [deprecated = true];</code>
      */
     @java.lang.Deprecated public com.google.protobuf.ByteString
-    getNextBatchKeyBytes() {
+        getNextBatchKeyBytes() {
       java.lang.Object ref = nextBatchKey_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b =
-                com.google.protobuf.ByteString.copyFromUtf8(
-                        (java.lang.String) ref);
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
         nextBatchKey_ = b;
         return b;
       } else {
@@ -2751,7 +2826,7 @@ public final class CloudSignProtos {
     }
 
     public void writeTo(com.google.protobuf.CodedOutputStream output)
-            throws java.io.IOException {
+                        throws java.io.IOException {
       getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeInt64(1, signedReceiptsCount_);
@@ -2770,11 +2845,11 @@ public final class CloudSignProtos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-                .computeInt64Size(1, signedReceiptsCount_);
+          .computeInt64Size(1, signedReceiptsCount_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-                .computeBytesSize(2, getNextBatchKeyBytes());
+          .computeBytesSize(2, getNextBatchKeyBytes());
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -2784,60 +2859,60 @@ public final class CloudSignProtos {
     private static final long serialVersionUID = 0L;
     @java.lang.Override
     protected java.lang.Object writeReplace()
-            throws java.io.ObjectStreamException {
+        throws java.io.ObjectStreamException {
       return super.writeReplace();
     }
 
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseFrom(
-            com.google.protobuf.ByteString data)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseFrom(
-            com.google.protobuf.ByteString data,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseFrom(byte[] data)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseFrom(
-            byte[] data,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseFrom(java.io.InputStream input)
-            throws java.io.IOException {
+        throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseFrom(
-            java.io.InputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseDelimitedFrom(java.io.InputStream input)
-            throws java.io.IOException {
+        throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseDelimitedFrom(
-            java.io.InputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
       return PARSER.parseDelimitedFrom(input, extensionRegistry);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseFrom(
-            com.google.protobuf.CodedInputStream input)
-            throws java.io.IOException {
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
       return PARSER.parseFrom(input);
     }
     public static Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parseFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
       return PARSER.parseFrom(input, extensionRegistry);
     }
 
@@ -2850,7 +2925,7 @@ public final class CloudSignProtos {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -2858,19 +2933,19 @@ public final class CloudSignProtos {
      * Protobuf type {@code Diadoc.Api.Proto.AutosignReceiptsResult}
      */
     public static final class Builder extends
-            com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-            // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.AutosignReceiptsResult)
-            Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResultOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:Diadoc.Api.Proto.AutosignReceiptsResult)
+        Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResultOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
+          getDescriptor() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internalGetFieldAccessorTable() {
+          internalGetFieldAccessorTable() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_fieldAccessorTable
-                .ensureFieldAccessorsInitialized(
-                        Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult.class, Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult.Builder.class);
+            .ensureFieldAccessorsInitialized(
+                Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult.class, Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult.Builder.class);
       }
 
       // Construct using Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult.newBuilder()
@@ -2879,7 +2954,7 @@ public final class CloudSignProtos {
       }
 
       private Builder(
-              com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -2905,7 +2980,7 @@ public final class CloudSignProtos {
       }
 
       public com.google.protobuf.Descriptors.Descriptor
-      getDescriptorForType() {
+          getDescriptorForType() {
         return Diadoc.Api.Proto.CloudSignProtos.internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_descriptor;
       }
 
@@ -2963,20 +3038,20 @@ public final class CloudSignProtos {
 
       public final boolean isInitialized() {
         if (!hasSignedReceiptsCount()) {
-
+          
           return false;
         }
         if (!hasNextBatchKey()) {
-
+          
           return false;
         }
         return true;
       }
 
       public Builder mergeFrom(
-              com.google.protobuf.CodedInputStream input,
-              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws java.io.IOException {
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
         Diadoc.Api.Proto.CloudSignProtos.AutosignReceiptsResult parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
@@ -3038,7 +3113,7 @@ public final class CloudSignProtos {
         java.lang.Object ref = nextBatchKey_;
         if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
-                  (com.google.protobuf.ByteString) ref;
+              (com.google.protobuf.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             nextBatchKey_ = s;
@@ -3052,12 +3127,12 @@ public final class CloudSignProtos {
        * <code>required string NextBatchKey = 2 [deprecated = true];</code>
        */
       @java.lang.Deprecated public com.google.protobuf.ByteString
-      getNextBatchKeyBytes() {
+          getNextBatchKeyBytes() {
         java.lang.Object ref = nextBatchKey_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b =
-                  com.google.protobuf.ByteString.copyFromUtf8(
-                          (java.lang.String) ref);
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
           nextBatchKey_ = b;
           return b;
         } else {
@@ -3068,11 +3143,11 @@ public final class CloudSignProtos {
        * <code>required string NextBatchKey = 2 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Builder setNextBatchKey(
-              java.lang.String value) {
+          java.lang.String value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000002;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
         nextBatchKey_ = value;
         onChanged();
         return this;
@@ -3090,11 +3165,11 @@ public final class CloudSignProtos {
        * <code>required string NextBatchKey = 2 [deprecated = true];</code>
        */
       @java.lang.Deprecated public Builder setNextBatchKeyBytes(
-              com.google.protobuf.ByteString value) {
+          com.google.protobuf.ByteString value) {
         if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000002;
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
         nextBatchKey_ = value;
         onChanged();
         return this;
@@ -3111,96 +3186,119 @@ public final class CloudSignProtos {
     // @@protoc_insertion_point(class_scope:Diadoc.Api.Proto.AutosignReceiptsResult)
   }
 
+  public static final int FILE_DEPRECATED_FIELD_NUMBER = 50001;
+  /**
+   * <code>extend .google.protobuf.FileOptions { ... }</code>
+   */
+  public static final
+    com.google.protobuf.GeneratedMessage.GeneratedExtension<
+      com.google.protobuf.DescriptorProtos.FileOptions,
+      java.lang.Boolean> fileDeprecated = com.google.protobuf.GeneratedMessage
+          .newFileScopedGeneratedExtension(
+        java.lang.Boolean.class,
+        null);
   private static final com.google.protobuf.Descriptors.Descriptor
-          internal_static_Diadoc_Api_Proto_CloudSignRequest_descriptor;
+    internal_static_Diadoc_Api_Proto_CloudSignRequest_descriptor;
   private static
-  com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internal_static_Diadoc_Api_Proto_CloudSignRequest_fieldAccessorTable;
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_Diadoc_Api_Proto_CloudSignRequest_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
-          internal_static_Diadoc_Api_Proto_CloudSignFile_descriptor;
+    internal_static_Diadoc_Api_Proto_CloudSignFile_descriptor;
   private static
-  com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internal_static_Diadoc_Api_Proto_CloudSignFile_fieldAccessorTable;
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_Diadoc_Api_Proto_CloudSignFile_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
-          internal_static_Diadoc_Api_Proto_CloudSignResult_descriptor;
+    internal_static_Diadoc_Api_Proto_CloudSignResult_descriptor;
   private static
-  com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internal_static_Diadoc_Api_Proto_CloudSignResult_fieldAccessorTable;
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_Diadoc_Api_Proto_CloudSignResult_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
-          internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_descriptor;
+    internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_descriptor;
   private static
-  com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_fieldAccessorTable;
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
-          internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_descriptor;
+    internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_descriptor;
   private static
-  com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_fieldAccessorTable;
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
-  getDescriptor() {
+      getDescriptor() {
     return descriptor;
   }
   private static com.google.protobuf.Descriptors.FileDescriptor
-          descriptor;
+      descriptor;
   static {
     java.lang.String[] descriptorData = {
-            "\n\017CloudSign.proto\022\020Diadoc.Api.Proto\032\020Con" +
-                    "tent_v2.proto\"F\n\020CloudSignRequest\0222\n\005Fil" +
-                    "es\030\001 \003(\0132\037.Diadoc.Api.Proto.CloudSignFil" +
-                    "eB\002\030\001\"X\n\rCloudSignFile\0221\n\007Content\030\001 \001(\0132" +
-                    "\034.Diadoc.Api.Proto.Content_v2B\002\030\001\022\024\n\010Fil" +
-                    "eName\030\002 \001(\tB\002\030\001\"$\n\017CloudSignResult\022\021\n\005To" +
-                    "ken\030\001 \001(\tB\002\030\001\"N\n\026CloudSignConfirmResult\022" +
-                    "4\n\nSignatures\030\001 \003(\0132\034.Diadoc.Api.Proto.C" +
-                    "ontent_v2B\002\030\001\"S\n\026AutosignReceiptsResult\022" +
-                    "\037\n\023SignedReceiptsCount\030\001 \002(\003B\002\030\001\022\030\n\014Next",
-            "BatchKey\030\002 \002(\tB\002\030\001B\021B\017CloudSignProtos"
+      "\n\017CloudSign.proto\022\020Diadoc.Api.Proto\032\020Con" +
+      "tent_v2.proto\032 google/protobuf/descripto" +
+      "r.proto\"J\n\020CloudSignRequest\0222\n\005Files\030\001 \003" +
+      "(\0132\037.Diadoc.Api.Proto.CloudSignFileB\002\030\001:" +
+      "\002\030\001\"r\n\rCloudSignFile\0221\n\007Content\030\001 \001(\0132\034." +
+      "Diadoc.Api.Proto.Content_v2B\002\030\001\022\024\n\010FileN" +
+      "ame\030\002 \001(\tB\002\030\001\022\030\n\ndeprecated\030\003 \001(\010:\004true\"" +
+      "(\n\017CloudSignResult\022\021\n\005Token\030\001 \001(\tB\002\030\001:\002\030" +
+      "\001\"R\n\026CloudSignConfirmResult\0224\n\nSignature" +
+      "s\030\001 \003(\0132\034.Diadoc.Api.Proto.Content_v2B\002\030",
+      "\001:\002\030\001\"W\n\026AutosignReceiptsResult\022\037\n\023Signe" +
+      "dReceiptsCount\030\001 \002(\003B\002\030\001\022\030\n\014NextBatchKey" +
+      "\030\002 \002(\tB\002\030\001:\002\030\001:7\n\017file_deprecated\022\034.goog" +
+      "le.protobuf.FileOptions\030\321\206\003 \001(\010B\025B\017Cloud" +
+      "SignProtos\210\265\030\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-            new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-              public com.google.protobuf.ExtensionRegistry assignDescriptors(
-                      com.google.protobuf.Descriptors.FileDescriptor root) {
-                descriptor = root;
-                return null;
-              }
-            };
+        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
+          public com.google.protobuf.ExtensionRegistry assignDescriptors(
+              com.google.protobuf.Descriptors.FileDescriptor root) {
+            descriptor = root;
+            return null;
+          }
+        };
     com.google.protobuf.Descriptors.FileDescriptor
-            .internalBuildGeneratedFileFrom(descriptorData,
-                    new com.google.protobuf.Descriptors.FileDescriptor[] {
-                            Diadoc.Api.Proto.Content_v2Protos.getDescriptor(),
-                    }, assigner);
+      .internalBuildGeneratedFileFrom(descriptorData,
+        new com.google.protobuf.Descriptors.FileDescriptor[] {
+          Diadoc.Api.Proto.Content_v2Protos.getDescriptor(),
+          com.google.protobuf.DescriptorProtos.getDescriptor(),
+        }, assigner);
     internal_static_Diadoc_Api_Proto_CloudSignRequest_descriptor =
-            getDescriptor().getMessageTypes().get(0);
+      getDescriptor().getMessageTypes().get(0);
     internal_static_Diadoc_Api_Proto_CloudSignRequest_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-            internal_static_Diadoc_Api_Proto_CloudSignRequest_descriptor,
-            new java.lang.String[] { "Files", });
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_Diadoc_Api_Proto_CloudSignRequest_descriptor,
+        new java.lang.String[] { "Files", });
     internal_static_Diadoc_Api_Proto_CloudSignFile_descriptor =
-            getDescriptor().getMessageTypes().get(1);
+      getDescriptor().getMessageTypes().get(1);
     internal_static_Diadoc_Api_Proto_CloudSignFile_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-            internal_static_Diadoc_Api_Proto_CloudSignFile_descriptor,
-            new java.lang.String[] { "Content", "FileName", });
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_Diadoc_Api_Proto_CloudSignFile_descriptor,
+        new java.lang.String[] { "Content", "FileName", "Deprecated", });
     internal_static_Diadoc_Api_Proto_CloudSignResult_descriptor =
-            getDescriptor().getMessageTypes().get(2);
+      getDescriptor().getMessageTypes().get(2);
     internal_static_Diadoc_Api_Proto_CloudSignResult_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-            internal_static_Diadoc_Api_Proto_CloudSignResult_descriptor,
-            new java.lang.String[] { "Token", });
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_Diadoc_Api_Proto_CloudSignResult_descriptor,
+        new java.lang.String[] { "Token", });
     internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_descriptor =
-            getDescriptor().getMessageTypes().get(3);
+      getDescriptor().getMessageTypes().get(3);
     internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-            internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_descriptor,
-            new java.lang.String[] { "Signatures", });
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_Diadoc_Api_Proto_CloudSignConfirmResult_descriptor,
+        new java.lang.String[] { "Signatures", });
     internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_descriptor =
-            getDescriptor().getMessageTypes().get(4);
+      getDescriptor().getMessageTypes().get(4);
     internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-            internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_descriptor,
-            new java.lang.String[] { "SignedReceiptsCount", "NextBatchKey", });
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_Diadoc_Api_Proto_AutosignReceiptsResult_descriptor,
+        new java.lang.String[] { "SignedReceiptsCount", "NextBatchKey", });
+    fileDeprecated.internalInit(descriptor.getExtensions().get(0));
+    com.google.protobuf.ExtensionRegistry registry =
+        com.google.protobuf.ExtensionRegistry.newInstance();
+    registry.add(Diadoc.Api.Proto.CloudSignProtos.fileDeprecated);
+    com.google.protobuf.Descriptors.FileDescriptor
+        .internalUpdateFileDescriptor(descriptor, registry);
     Diadoc.Api.Proto.Content_v2Protos.getDescriptor();
+    com.google.protobuf.DescriptorProtos.getDescriptor();
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/src/main/java/Diadoc/Api/Proto/Events/DiadocMessage_PostApiProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Events/DiadocMessage_PostApiProtos.java
@@ -77921,6 +77921,15 @@ public final class DiadocMessage_PostApiProtos {
      */
     Diadoc.Api.Proto.Invoicing.Signers.ExtendedSignerProtos.ExtendedSignerOrBuilder getExtendedSignerOrBuilder(
         int index);
+
+    /**
+     * <code>optional bytes SignerContent = 5;</code>
+     */
+    boolean hasSignerContent();
+    /**
+     * <code>optional bytes SignerContent = 5;</code>
+     */
+    com.google.protobuf.ByteString getSignerContent();
   }
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Events.DraftDocumentToPatch}
@@ -78012,6 +78021,11 @@ public final class DiadocMessage_PostApiProtos {
                 mutable_bitField0_ |= 0x00000008;
               }
               extendedSigner_.add(input.readMessage(Diadoc.Api.Proto.Invoicing.Signers.ExtendedSignerProtos.ExtendedSigner.PARSER, extensionRegistry));
+              break;
+            }
+            case 42: {
+              bitField0_ |= 0x00000008;
+              signerContent_ = input.readBytes();
               break;
             }
           }
@@ -78176,11 +78190,27 @@ public final class DiadocMessage_PostApiProtos {
       return extendedSigner_.get(index);
     }
 
+    public static final int SIGNERCONTENT_FIELD_NUMBER = 5;
+    private com.google.protobuf.ByteString signerContent_;
+    /**
+     * <code>optional bytes SignerContent = 5;</code>
+     */
+    public boolean hasSignerContent() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>optional bytes SignerContent = 5;</code>
+     */
+    public com.google.protobuf.ByteString getSignerContent() {
+      return signerContent_;
+    }
+
     private void initFields() {
       documentId_ = Diadoc.Api.Proto.DocumentIdProtos.DocumentId.getDefaultInstance();
       toBoxId_ = "";
       signer_ = Diadoc.Api.Proto.Invoicing.SignerProtos.Signer.getDefaultInstance();
       extendedSigner_ = java.util.Collections.emptyList();
+      signerContent_ = com.google.protobuf.ByteString.EMPTY;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -78227,6 +78257,9 @@ public final class DiadocMessage_PostApiProtos {
       for (int i = 0; i < extendedSigner_.size(); i++) {
         output.writeMessage(4, extendedSigner_.get(i));
       }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        output.writeBytes(5, signerContent_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -78251,6 +78284,10 @@ public final class DiadocMessage_PostApiProtos {
       for (int i = 0; i < extendedSigner_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(4, extendedSigner_.get(i));
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(5, signerContent_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -78392,6 +78429,8 @@ public final class DiadocMessage_PostApiProtos {
         } else {
           extendedSignerBuilder_.clear();
         }
+        signerContent_ = com.google.protobuf.ByteString.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000010);
         return this;
       }
 
@@ -78449,6 +78488,10 @@ public final class DiadocMessage_PostApiProtos {
         } else {
           result.extendedSigner_ = extendedSignerBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+          to_bitField0_ |= 0x00000008;
+        }
+        result.signerContent_ = signerContent_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -78501,6 +78544,9 @@ public final class DiadocMessage_PostApiProtos {
               extendedSignerBuilder_.addAllMessages(other.extendedSigner_);
             }
           }
+        }
+        if (other.hasSignerContent()) {
+          setSignerContent(other.getSignerContent());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -79097,6 +79143,41 @@ public final class DiadocMessage_PostApiProtos {
         return extendedSignerBuilder_;
       }
 
+      private com.google.protobuf.ByteString signerContent_ = com.google.protobuf.ByteString.EMPTY;
+      /**
+       * <code>optional bytes SignerContent = 5;</code>
+       */
+      public boolean hasSignerContent() {
+        return ((bitField0_ & 0x00000010) == 0x00000010);
+      }
+      /**
+       * <code>optional bytes SignerContent = 5;</code>
+       */
+      public com.google.protobuf.ByteString getSignerContent() {
+        return signerContent_;
+      }
+      /**
+       * <code>optional bytes SignerContent = 5;</code>
+       */
+      public Builder setSignerContent(com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000010;
+        signerContent_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bytes SignerContent = 5;</code>
+       */
+      public Builder clearSignerContent() {
+        bitField0_ = (bitField0_ & ~0x00000010);
+        signerContent_ = getDefaultInstance().getSignerContent();
+        onChanged();
+        return this;
+      }
+
       // @@protoc_insertion_point(builder_scope:Diadoc.Api.Proto.Events.DraftDocumentToPatch)
     }
 
@@ -79217,6 +79298,15 @@ public final class DiadocMessage_PostApiProtos {
      */
     Diadoc.Api.Proto.Invoicing.Signers.ExtendedSignerProtos.ExtendedSignerOrBuilder getExtendedSignerOrBuilder(
         int index);
+
+    /**
+     * <code>optional bytes SignerContent = 8;</code>
+     */
+    boolean hasSignerContent();
+    /**
+     * <code>optional bytes SignerContent = 8;</code>
+     */
+    com.google.protobuf.ByteString getSignerContent();
   }
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Events.ContentToPatch}
@@ -79326,6 +79416,11 @@ public final class DiadocMessage_PostApiProtos {
                 mutable_bitField0_ |= 0x00000040;
               }
               extendedSigner_.add(input.readMessage(Diadoc.Api.Proto.Invoicing.Signers.ExtendedSignerProtos.ExtendedSigner.PARSER, extensionRegistry));
+              break;
+            }
+            case 66: {
+              bitField0_ |= 0x00000040;
+              signerContent_ = input.readBytes();
               break;
             }
           }
@@ -79616,6 +79711,21 @@ public final class DiadocMessage_PostApiProtos {
       return extendedSigner_.get(index);
     }
 
+    public static final int SIGNERCONTENT_FIELD_NUMBER = 8;
+    private com.google.protobuf.ByteString signerContent_;
+    /**
+     * <code>optional bytes SignerContent = 8;</code>
+     */
+    public boolean hasSignerContent() {
+      return ((bitField0_ & 0x00000040) == 0x00000040);
+    }
+    /**
+     * <code>optional bytes SignerContent = 8;</code>
+     */
+    public com.google.protobuf.ByteString getSignerContent() {
+      return signerContent_;
+    }
+
     private void initFields() {
       typeNamedId_ = "";
       function_ = "";
@@ -79624,6 +79734,7 @@ public final class DiadocMessage_PostApiProtos {
       toBoxId_ = "";
       signer_ = Diadoc.Api.Proto.Invoicing.SignerProtos.Signer.getDefaultInstance();
       extendedSigner_ = java.util.Collections.emptyList();
+      signerContent_ = com.google.protobuf.ByteString.EMPTY;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -79687,6 +79798,9 @@ public final class DiadocMessage_PostApiProtos {
       for (int i = 0; i < extendedSigner_.size(); i++) {
         output.writeMessage(7, extendedSigner_.get(i));
       }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        output.writeBytes(8, signerContent_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -79723,6 +79837,10 @@ public final class DiadocMessage_PostApiProtos {
       for (int i = 0; i < extendedSigner_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(7, extendedSigner_.get(i));
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(8, signerContent_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -79870,6 +79988,8 @@ public final class DiadocMessage_PostApiProtos {
         } else {
           extendedSignerBuilder_.clear();
         }
+        signerContent_ = com.google.protobuf.ByteString.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000080);
         return this;
       }
 
@@ -79939,6 +80059,10 @@ public final class DiadocMessage_PostApiProtos {
         } else {
           result.extendedSigner_ = extendedSignerBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
+          to_bitField0_ |= 0x00000040;
+        }
+        result.signerContent_ = signerContent_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -80006,6 +80130,9 @@ public final class DiadocMessage_PostApiProtos {
               extendedSignerBuilder_.addAllMessages(other.extendedSigner_);
             }
           }
+        }
+        if (other.hasSignerContent()) {
+          setSignerContent(other.getSignerContent());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -80838,6 +80965,41 @@ public final class DiadocMessage_PostApiProtos {
         return extendedSignerBuilder_;
       }
 
+      private com.google.protobuf.ByteString signerContent_ = com.google.protobuf.ByteString.EMPTY;
+      /**
+       * <code>optional bytes SignerContent = 8;</code>
+       */
+      public boolean hasSignerContent() {
+        return ((bitField0_ & 0x00000080) == 0x00000080);
+      }
+      /**
+       * <code>optional bytes SignerContent = 8;</code>
+       */
+      public com.google.protobuf.ByteString getSignerContent() {
+        return signerContent_;
+      }
+      /**
+       * <code>optional bytes SignerContent = 8;</code>
+       */
+      public Builder setSignerContent(com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000080;
+        signerContent_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bytes SignerContent = 8;</code>
+       */
+      public Builder clearSignerContent() {
+        bitField0_ = (bitField0_ & ~0x00000080);
+        signerContent_ = getDefaultInstance().getSignerContent();
+        onChanged();
+        return this;
+      }
+
       // @@protoc_insertion_point(builder_scope:Diadoc.Api.Proto.Events.ContentToPatch)
     }
 
@@ -80902,6 +81064,15 @@ public final class DiadocMessage_PostApiProtos {
      */
     Diadoc.Api.Proto.Invoicing.Signers.ExtendedSignerProtos.ExtendedSignerOrBuilder getExtendedSignerOrBuilder(
         int index);
+
+    /**
+     * <code>optional bytes SignerContent = 4;</code>
+     */
+    boolean hasSignerContent();
+    /**
+     * <code>optional bytes SignerContent = 4;</code>
+     */
+    com.google.protobuf.ByteString getSignerContent();
   }
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Events.DocumentToPatch}
@@ -80987,6 +81158,11 @@ public final class DiadocMessage_PostApiProtos {
                 mutable_bitField0_ |= 0x00000004;
               }
               extendedSigner_.add(input.readMessage(Diadoc.Api.Proto.Invoicing.Signers.ExtendedSignerProtos.ExtendedSigner.PARSER, extensionRegistry));
+              break;
+            }
+            case 34: {
+              bitField0_ |= 0x00000004;
+              signerContent_ = input.readBytes();
               break;
             }
           }
@@ -81109,10 +81285,26 @@ public final class DiadocMessage_PostApiProtos {
       return extendedSigner_.get(index);
     }
 
+    public static final int SIGNERCONTENT_FIELD_NUMBER = 4;
+    private com.google.protobuf.ByteString signerContent_;
+    /**
+     * <code>optional bytes SignerContent = 4;</code>
+     */
+    public boolean hasSignerContent() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>optional bytes SignerContent = 4;</code>
+     */
+    public com.google.protobuf.ByteString getSignerContent() {
+      return signerContent_;
+    }
+
     private void initFields() {
       documentId_ = Diadoc.Api.Proto.DocumentIdProtos.DocumentId.getDefaultInstance();
       signer_ = Diadoc.Api.Proto.Invoicing.SignerProtos.Signer.getDefaultInstance();
       extendedSigner_ = java.util.Collections.emptyList();
+      signerContent_ = com.google.protobuf.ByteString.EMPTY;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -81156,6 +81348,9 @@ public final class DiadocMessage_PostApiProtos {
       for (int i = 0; i < extendedSigner_.size(); i++) {
         output.writeMessage(3, extendedSigner_.get(i));
       }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeBytes(4, signerContent_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -81176,6 +81371,10 @@ public final class DiadocMessage_PostApiProtos {
       for (int i = 0; i < extendedSigner_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(3, extendedSigner_.get(i));
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(4, signerContent_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -81315,6 +81514,8 @@ public final class DiadocMessage_PostApiProtos {
         } else {
           extendedSignerBuilder_.clear();
         }
+        signerContent_ = com.google.protobuf.ByteString.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
 
@@ -81368,6 +81569,10 @@ public final class DiadocMessage_PostApiProtos {
         } else {
           result.extendedSigner_ = extendedSignerBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.signerContent_ = signerContent_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -81415,6 +81620,9 @@ public final class DiadocMessage_PostApiProtos {
               extendedSignerBuilder_.addAllMessages(other.extendedSigner_);
             }
           }
+        }
+        if (other.hasSignerContent()) {
+          setSignerContent(other.getSignerContent());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -81933,6 +82141,41 @@ public final class DiadocMessage_PostApiProtos {
           extendedSigner_ = null;
         }
         return extendedSignerBuilder_;
+      }
+
+      private com.google.protobuf.ByteString signerContent_ = com.google.protobuf.ByteString.EMPTY;
+      /**
+       * <code>optional bytes SignerContent = 4;</code>
+       */
+      public boolean hasSignerContent() {
+        return ((bitField0_ & 0x00000008) == 0x00000008);
+      }
+      /**
+       * <code>optional bytes SignerContent = 4;</code>
+       */
+      public com.google.protobuf.ByteString getSignerContent() {
+        return signerContent_;
+      }
+      /**
+       * <code>optional bytes SignerContent = 4;</code>
+       */
+      public Builder setSignerContent(com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000008;
+        signerContent_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bytes SignerContent = 4;</code>
+       */
+      public Builder clearSignerContent() {
+        bitField0_ = (bitField0_ & ~0x00000008);
+        signerContent_ = getDefaultInstance().getSignerContent();
+        onChanged();
+        return this;
       }
 
       // @@protoc_insertion_point(builder_scope:Diadoc.Api.Proto.Events.DocumentToPatch)
@@ -100510,93 +100753,95 @@ public final class DiadocMessage_PostApiProtos {
       "umentToPatch\022;\n\tDocuments\030\003 \003(\0132(.Diadoc" +
       ".Api.Proto.Events.DocumentToPatch\0229\n\010Con" +
       "tents\030\004 \003(\0132\'.Diadoc.Api.Proto.Events.Co",
-      "ntentToPatch\"\331\001\n\024DraftDocumentToPatch\0220\n" +
+      "ntentToPatch\"\360\001\n\024DraftDocumentToPatch\0220\n" +
       "\nDocumentId\030\001 \002(\0132\034.Diadoc.Api.Proto.Doc" +
       "umentId\022\017\n\007ToBoxId\030\002 \001(\t\0222\n\006Signer\030\003 \001(\013" +
       "2\".Diadoc.Api.Proto.Invoicing.Signer\022J\n\016" +
       "ExtendedSigner\030\004 \003(\01322.Diadoc.Api.Proto." +
-      "Invoicing.Signers.ExtendedSigner\"\224\002\n\016Con" +
-      "tentToPatch\022\023\n\013TypeNamedId\030\001 \002(\t\022\020\n\010Func" +
-      "tion\030\002 \002(\t\022\017\n\007Version\030\003 \002(\t\0229\n\007Content\030\004" +
-      " \002(\0132(.Diadoc.Api.Proto.Events.UnsignedC" +
-      "ontent\022\017\n\007ToBoxId\030\005 \001(\t\0222\n\006Signer\030\006 \001(\0132",
-      "\".Diadoc.Api.Proto.Invoicing.Signer\022J\n\016E" +
-      "xtendedSigner\030\007 \003(\01322.Diadoc.Api.Proto.I" +
-      "nvoicing.Signers.ExtendedSigner\"\303\001\n\017Docu" +
-      "mentToPatch\0220\n\nDocumentId\030\001 \002(\0132\034.Diadoc" +
-      ".Api.Proto.DocumentId\0222\n\006Signer\030\002 \001(\0132\"." +
-      "Diadoc.Api.Proto.Invoicing.Signer\022J\n\016Ext" +
-      "endedSigner\030\003 \003(\01322.Diadoc.Api.Proto.Inv" +
-      "oicing.Signers.ExtendedSigner\"u\n\026Documen" +
-      "tPatchedContent\0220\n\nDocumentId\030\001 \002(\0132\034.Di" +
-      "adoc.Api.Proto.DocumentId\022\030\n\020PatchedCont",
-      "entId\030\002 \002(\t\022\017\n\007Content\030\003 \001(\014\"r\n\036PrepareD" +
-      "ocumentsToSignResponse\022P\n\027DocumentPatche" +
-      "dContents\030\001 \003(\0132/.Diadoc.Api.Proto.Event" +
-      "s.DocumentPatchedContent\"y\n\rMessageToSen" +
-      "d\022\r\n\005BoxId\030\001 \002(\t\022\021\n\tMessageId\030\002 \002(\t\022F\n\022D" +
-      "ocumentSignatures\030\003 \003(\0132*.Diadoc.Api.Pro" +
-      "to.Events.DocumentSignature\"\204\001\n\033Revocati" +
-      "onRequestAttachment\022\026\n\016ParentEntityId\030\001 " +
-      "\002(\t\022=\n\rSignedContent\030\002 \002(\0132&.Diadoc.Api." +
-      "Proto.Events.SignedContent\022\016\n\006Labels\030\003 \003",
-      "(\t\"\210\001\n\037XmlSignatureRejectionAttachment\022\026" +
-      "\n\016ParentEntityId\030\001 \002(\t\022=\n\rSignedContent\030" +
-      "\002 \002(\0132&.Diadoc.Api.Proto.Events.SignedCo" +
-      "ntent\022\016\n\006Labels\030\003 \003(\t\"\221\001\n\031RoamingNotific" +
-      "ationToPost\022\r\n\005BoxId\030\001 \002(\t\022\017\n\007EventId\030\002 " +
-      "\002(\t\022\017\n\007Success\030\003 \002(\010\022\023\n\013Description\030\004 \001(" +
-      "\t\022\021\n\tMessageId\030\005 \001(\t\022\033\n\023NotifiableEntity" +
-      "Ids\030\006 \003(\t\"\213\001\n\017CustomDataPatch\022\026\n\016ParentE" +
-      "ntityId\030\001 \002(\t\022D\n\tOperation\030\002 \002(\01621.Diado" +
-      "c.Api.Proto.Events.CustomDataPatchOperat",
-      "ion\022\013\n\003Key\030\003 \002(\t\022\r\n\005Value\030\004 \001(\t\"\254\001\n\031Edit" +
-      "DocumentPacketCommand\022\022\n\nDocumentId\030\001 \002(" +
-      "\t\022:\n\024AddDocumentsToPacket\030\002 \003(\0132\034.Diadoc" +
-      ".Api.Proto.DocumentId\022?\n\031RemoveDocuments" +
-      "FromPacket\030\003 \003(\0132\034.Diadoc.Api.Proto.Docu" +
-      "mentId\"d\n\026ResolutionRouteRemoval\022\026\n\016Pare" +
-      "ntEntityId\030\001 \002(\t\022\017\n\007RouteId\030\002 \002(\t\022\021\n\007Com" +
-      "ment\030\003 \001(\t:\000\022\016\n\006Labels\030\004 \003(\t\"\225\003\n\016Templat" +
-      "eToPost\022\021\n\tFromBoxId\030\001 \002(\t\022\017\n\007ToBoxId\030\002 " +
-      "\002(\t\022\030\n\020MessageFromBoxId\030\003 \002(\t\022\026\n\016Message",
-      "ToBoxId\030\004 \002(\t\022\035\n\025MessageToDepartmentId\030\005" +
-      " \001(\t\022P\n\023DocumentAttachments\030\006 \003(\01323.Diad" +
-      "oc.Api.Proto.Events.TemplateDocumentAtta" +
-      "chment\0222\n\010LockMode\030\007 \001(\0162\032.Diadoc.Api.Pr" +
-      "oto.LockMode:\004None\022\030\n\020FromDepartmentId\030\010" +
-      " \001(\t\022\026\n\016ToDepartmentId\030\t \001(\t\022\031\n\021MessageP" +
-      "roxyBoxId\030\n \001(\t\022 \n\030MessageProxyDepartmen" +
-      "tId\030\013 \001(\t\022\031\n\nIsReusable\030\014 \001(\010:\005false\"\373\003\n" +
-      "\032TemplateDocumentAttachment\022A\n\017UnsignedC" +
-      "ontent\030\001 \002(\0132(.Diadoc.Api.Proto.Events.U",
-      "nsignedContent\022\017\n\007Comment\030\002 \001(\t\022\023\n\013TypeN" +
-      "amedId\030\003 \002(\t\022\020\n\010Function\030\004 \001(\t\022\017\n\007Versio" +
-      "n\030\005 \001(\t\0227\n\010Metadata\030\006 \003(\0132%.Diadoc.Api.P" +
-      "roto.Events.MetadataItem\022\022\n\nWorkflowId\030\007" +
-      " \001(\005\022\030\n\020CustomDocumentId\030\010 \001(\t\022\030\n\020Editin" +
-      "gSettingId\030\t \001(\t\022%\n\026NeedRecipientSignatu" +
-      "re\030\n \001(\010:\005false\022S\n\030PredefinedRecipientTi" +
-      "tle\030\013 \001(\01321.Diadoc.Api.Proto.Events.Pred" +
-      "efinedRecipientTitle\022\036\n\017RefusalDisabled\030" +
-      "\014 \001(\010:\005false\0224\n\nCustomData\030\r \003(\0132 .Diado",
-      "c.Api.Proto.CustomDataItem\"[\n\023TemplatePa" +
-      "tchToPost\022D\n\010Refusals\030\001 \003(\01322.Diadoc.Api" +
-      ".Proto.Events.TemplateRefusalAttachment\"" +
-      "P\n\031TemplateRefusalAttachment\022\022\n\nDocument" +
-      "Id\030\001 \002(\t\022\017\n\007Comment\030\002 \001(\t\022\016\n\006Labels\030\003 \003(" +
-      "\t\"]\n\030PredefinedRecipientTitle\022A\n\017Unsigne" +
-      "dContent\030\001 \002(\0132(.Diadoc.Api.Proto.Events" +
-      ".UnsignedContent\"7\n\017UnsignedContent\022\017\n\007C" +
-      "ontent\030\001 \001(\014\022\023\n\013NameOnShelf\030\002 \001(\t\"\223\001\n\034Te" +
-      "mplateTransformationToPost\022\r\n\005BoxId\030\001 \002(",
-      "\t\022\022\n\nTemplateId\030\002 \002(\t\022P\n\027DocumentTransfo" +
-      "rmations\030\003 \003(\0132/.Diadoc.Api.Proto.Events" +
-      ".DocumentTransformation\"F\n\026DocumentTrans" +
-      "formation\022\022\n\nDocumentId\030\001 \002(\t\022\030\n\020CustomD" +
-      "ocumentId\030\002 \001(\t*/\n\030CustomDataPatchOperat" +
-      "ion\022\007\n\003Set\020\000\022\n\n\006Remove\020\001B\035B\033DiadocMessag" +
-      "e_PostApiProtos"
+      "Invoicing.Signers.ExtendedSigner\022\025\n\rSign" +
+      "erContent\030\005 \001(\014\"\253\002\n\016ContentToPatch\022\023\n\013Ty" +
+      "peNamedId\030\001 \002(\t\022\020\n\010Function\030\002 \002(\t\022\017\n\007Ver" +
+      "sion\030\003 \002(\t\0229\n\007Content\030\004 \002(\0132(.Diadoc.Api" +
+      ".Proto.Events.UnsignedContent\022\017\n\007ToBoxId",
+      "\030\005 \001(\t\0222\n\006Signer\030\006 \001(\0132\".Diadoc.Api.Prot" +
+      "o.Invoicing.Signer\022J\n\016ExtendedSigner\030\007 \003" +
+      "(\01322.Diadoc.Api.Proto.Invoicing.Signers." +
+      "ExtendedSigner\022\025\n\rSignerContent\030\010 \001(\014\"\332\001" +
+      "\n\017DocumentToPatch\0220\n\nDocumentId\030\001 \002(\0132\034." +
+      "Diadoc.Api.Proto.DocumentId\0222\n\006Signer\030\002 " +
+      "\001(\0132\".Diadoc.Api.Proto.Invoicing.Signer\022" +
+      "J\n\016ExtendedSigner\030\003 \003(\01322.Diadoc.Api.Pro" +
+      "to.Invoicing.Signers.ExtendedSigner\022\025\n\rS" +
+      "ignerContent\030\004 \001(\014\"u\n\026DocumentPatchedCon",
+      "tent\0220\n\nDocumentId\030\001 \002(\0132\034.Diadoc.Api.Pr" +
+      "oto.DocumentId\022\030\n\020PatchedContentId\030\002 \002(\t" +
+      "\022\017\n\007Content\030\003 \001(\014\"r\n\036PrepareDocumentsToS" +
+      "ignResponse\022P\n\027DocumentPatchedContents\030\001" +
+      " \003(\0132/.Diadoc.Api.Proto.Events.DocumentP" +
+      "atchedContent\"y\n\rMessageToSend\022\r\n\005BoxId\030" +
+      "\001 \002(\t\022\021\n\tMessageId\030\002 \002(\t\022F\n\022DocumentSign" +
+      "atures\030\003 \003(\0132*.Diadoc.Api.Proto.Events.D" +
+      "ocumentSignature\"\204\001\n\033RevocationRequestAt" +
+      "tachment\022\026\n\016ParentEntityId\030\001 \002(\t\022=\n\rSign",
+      "edContent\030\002 \002(\0132&.Diadoc.Api.Proto.Event" +
+      "s.SignedContent\022\016\n\006Labels\030\003 \003(\t\"\210\001\n\037XmlS" +
+      "ignatureRejectionAttachment\022\026\n\016ParentEnt" +
+      "ityId\030\001 \002(\t\022=\n\rSignedContent\030\002 \002(\0132&.Dia" +
+      "doc.Api.Proto.Events.SignedContent\022\016\n\006La" +
+      "bels\030\003 \003(\t\"\221\001\n\031RoamingNotificationToPost" +
+      "\022\r\n\005BoxId\030\001 \002(\t\022\017\n\007EventId\030\002 \002(\t\022\017\n\007Succ" +
+      "ess\030\003 \002(\010\022\023\n\013Description\030\004 \001(\t\022\021\n\tMessag" +
+      "eId\030\005 \001(\t\022\033\n\023NotifiableEntityIds\030\006 \003(\t\"\213" +
+      "\001\n\017CustomDataPatch\022\026\n\016ParentEntityId\030\001 \002",
+      "(\t\022D\n\tOperation\030\002 \002(\01621.Diadoc.Api.Proto" +
+      ".Events.CustomDataPatchOperation\022\013\n\003Key\030" +
+      "\003 \002(\t\022\r\n\005Value\030\004 \001(\t\"\254\001\n\031EditDocumentPac" +
+      "ketCommand\022\022\n\nDocumentId\030\001 \002(\t\022:\n\024AddDoc" +
+      "umentsToPacket\030\002 \003(\0132\034.Diadoc.Api.Proto." +
+      "DocumentId\022?\n\031RemoveDocumentsFromPacket\030" +
+      "\003 \003(\0132\034.Diadoc.Api.Proto.DocumentId\"d\n\026R" +
+      "esolutionRouteRemoval\022\026\n\016ParentEntityId\030" +
+      "\001 \002(\t\022\017\n\007RouteId\030\002 \002(\t\022\021\n\007Comment\030\003 \001(\t:" +
+      "\000\022\016\n\006Labels\030\004 \003(\t\"\225\003\n\016TemplateToPost\022\021\n\t",
+      "FromBoxId\030\001 \002(\t\022\017\n\007ToBoxId\030\002 \002(\t\022\030\n\020Mess" +
+      "ageFromBoxId\030\003 \002(\t\022\026\n\016MessageToBoxId\030\004 \002" +
+      "(\t\022\035\n\025MessageToDepartmentId\030\005 \001(\t\022P\n\023Doc" +
+      "umentAttachments\030\006 \003(\01323.Diadoc.Api.Prot" +
+      "o.Events.TemplateDocumentAttachment\0222\n\010L" +
+      "ockMode\030\007 \001(\0162\032.Diadoc.Api.Proto.LockMod" +
+      "e:\004None\022\030\n\020FromDepartmentId\030\010 \001(\t\022\026\n\016ToD" +
+      "epartmentId\030\t \001(\t\022\031\n\021MessageProxyBoxId\030\n" +
+      " \001(\t\022 \n\030MessageProxyDepartmentId\030\013 \001(\t\022\031" +
+      "\n\nIsReusable\030\014 \001(\010:\005false\"\373\003\n\032TemplateDo",
+      "cumentAttachment\022A\n\017UnsignedContent\030\001 \002(" +
+      "\0132(.Diadoc.Api.Proto.Events.UnsignedCont" +
+      "ent\022\017\n\007Comment\030\002 \001(\t\022\023\n\013TypeNamedId\030\003 \002(" +
+      "\t\022\020\n\010Function\030\004 \001(\t\022\017\n\007Version\030\005 \001(\t\0227\n\010" +
+      "Metadata\030\006 \003(\0132%.Diadoc.Api.Proto.Events" +
+      ".MetadataItem\022\022\n\nWorkflowId\030\007 \001(\005\022\030\n\020Cus" +
+      "tomDocumentId\030\010 \001(\t\022\030\n\020EditingSettingId\030" +
+      "\t \001(\t\022%\n\026NeedRecipientSignature\030\n \001(\010:\005f" +
+      "alse\022S\n\030PredefinedRecipientTitle\030\013 \001(\01321" +
+      ".Diadoc.Api.Proto.Events.PredefinedRecip",
+      "ientTitle\022\036\n\017RefusalDisabled\030\014 \001(\010:\005fals" +
+      "e\0224\n\nCustomData\030\r \003(\0132 .Diadoc.Api.Proto" +
+      ".CustomDataItem\"[\n\023TemplatePatchToPost\022D" +
+      "\n\010Refusals\030\001 \003(\01322.Diadoc.Api.Proto.Even" +
+      "ts.TemplateRefusalAttachment\"P\n\031Template" +
+      "RefusalAttachment\022\022\n\nDocumentId\030\001 \002(\t\022\017\n" +
+      "\007Comment\030\002 \001(\t\022\016\n\006Labels\030\003 \003(\t\"]\n\030Predef" +
+      "inedRecipientTitle\022A\n\017UnsignedContent\030\001 " +
+      "\002(\0132(.Diadoc.Api.Proto.Events.UnsignedCo" +
+      "ntent\"7\n\017UnsignedContent\022\017\n\007Content\030\001 \001(",
+      "\014\022\023\n\013NameOnShelf\030\002 \001(\t\"\223\001\n\034TemplateTrans" +
+      "formationToPost\022\r\n\005BoxId\030\001 \002(\t\022\022\n\nTempla" +
+      "teId\030\002 \002(\t\022P\n\027DocumentTransformations\030\003 " +
+      "\003(\0132/.Diadoc.Api.Proto.Events.DocumentTr" +
+      "ansformation\"F\n\026DocumentTransformation\022\022" +
+      "\n\nDocumentId\030\001 \002(\t\022\030\n\020CustomDocumentId\030\002" +
+      " \001(\t*/\n\030CustomDataPatchOperation\022\007\n\003Set\020" +
+      "\000\022\n\n\006Remove\020\001B\035B\033DiadocMessage_PostApiPr" +
+      "otos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -100861,19 +101106,19 @@ public final class DiadocMessage_PostApiProtos {
     internal_static_Diadoc_Api_Proto_Events_DraftDocumentToPatch_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_Diadoc_Api_Proto_Events_DraftDocumentToPatch_descriptor,
-        new java.lang.String[] { "DocumentId", "ToBoxId", "Signer", "ExtendedSigner", });
+        new java.lang.String[] { "DocumentId", "ToBoxId", "Signer", "ExtendedSigner", "SignerContent", });
     internal_static_Diadoc_Api_Proto_Events_ContentToPatch_descriptor =
       getDescriptor().getMessageTypes().get(40);
     internal_static_Diadoc_Api_Proto_Events_ContentToPatch_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_Diadoc_Api_Proto_Events_ContentToPatch_descriptor,
-        new java.lang.String[] { "TypeNamedId", "Function", "Version", "Content", "ToBoxId", "Signer", "ExtendedSigner", });
+        new java.lang.String[] { "TypeNamedId", "Function", "Version", "Content", "ToBoxId", "Signer", "ExtendedSigner", "SignerContent", });
     internal_static_Diadoc_Api_Proto_Events_DocumentToPatch_descriptor =
       getDescriptor().getMessageTypes().get(41);
     internal_static_Diadoc_Api_Proto_Events_DocumentToPatch_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_Diadoc_Api_Proto_Events_DocumentToPatch_descriptor,
-        new java.lang.String[] { "DocumentId", "Signer", "ExtendedSigner", });
+        new java.lang.String[] { "DocumentId", "Signer", "ExtendedSigner", "SignerContent", });
     internal_static_Diadoc_Api_Proto_Events_DocumentPatchedContent_descriptor =
       getDescriptor().getMessageTypes().get(42);
     internal_static_Diadoc_Api_Proto_Events_DocumentPatchedContent_fieldAccessorTable = new

--- a/src/main/java/Diadoc/Api/sign/DiadocCloudCryptErrorCodes.java
+++ b/src/main/java/Diadoc/Api/sign/DiadocCloudCryptErrorCodes.java
@@ -1,5 +1,9 @@
 package Diadoc.Api.sign;
 
+/**
+ * Класс будет удален в следующей версии в связи с неактуальностью облачных подписаний
+ */
+@Deprecated
 public class DiadocCloudCryptErrorCodes {
     public static final String CloudCrypt_BadConfirmationCode = "CloudCrypt.BadConfirmationCode";
     public static final String CloudCrypt_ExpiredRequest = "CloudCrypt.ExpiredRequest";

--- a/src/main/java/Diadoc/Api/sign/SignClient.java
+++ b/src/main/java/Diadoc/Api/sign/SignClient.java
@@ -27,6 +27,10 @@ public class SignClient {
         return cloudSign(request, null);
     }
 
+    /**
+     * @deprecated Этот метод будет удалён в следующей мажорной версии.
+     * Для сценариев с подписаниями используйте методы: dssSign и dssSignResult
+     */
     public AsyncMethodResult cloudSign(CloudSignRequest cloudSignRequest, @Nullable String certificateThumbprint) throws DiadocSdkException {
         if (cloudSignRequest == null) {
             throw new IllegalArgumentException("cloudSignRequest");
@@ -45,6 +49,10 @@ public class SignClient {
         }
     }
 
+    /**
+     * @deprecated Этот метод будет удалён в следующей мажорной версии.
+     * Для сценариев с подписаниями используйте методы: {@link #dssSign(String, DssSignRequest)} и {@link #dssSignResult(String, String)}
+     */
     public CloudSignResult waitCloudSignResult(String taskId, Integer timeoutInMillis) throws DiadocSdkException {
         try {
             var data = diadocHttpClient.waitTaskResult("/CloudSignResult", taskId, timeoutInMillis);
@@ -54,6 +62,10 @@ public class SignClient {
         }
     }
 
+    /**
+     * @deprecated Этот метод будет удалён в следующей мажорной версии.
+     * Для сценариев с подписаниями используйте методы: {@link #dssSign(String, DssSignRequest)} и {@link #dssSignResult(String, String)}
+     */
     public AsyncMethodResult cloudSignConfirm(String token, String confirmationCode, boolean returnContent) throws DiadocSdkException {
         try {
             var url = new URIBuilder(diadocHttpClient.getBaseUrl())
@@ -204,11 +216,11 @@ public class SignClient {
         try {
             var result = diadocHttpClient.performRequest(
                     RequestBuilder.post(
-                            new URIBuilder(diadocHttpClient.getBaseUrl())
-                                    .setPath("/V2/ExtendedSignerDetails")
-                                    .addParameter("boxId", boxId)
-                                    .addParameter("thumbprint", thumbprint)
-                                    .addParameter("documentTitleType", Integer.toString(documentTitleType.getNumber())).build())
+                                    new URIBuilder(diadocHttpClient.getBaseUrl())
+                                            .setPath("/V2/ExtendedSignerDetails")
+                                            .addParameter("boxId", boxId)
+                                            .addParameter("thumbprint", thumbprint)
+                                            .addParameter("documentTitleType", Integer.toString(documentTitleType.getNumber())).build())
                             .setEntity(new ByteArrayEntity(signerDetails.toByteArray())));
             return ExtendedSignerDetails.parseFrom(result);
 


### PR DESCRIPTION
Добавлен универсальный подписант по 970 формату УПД в модели файла DiadocMessage-PostApi: DraftDocumentToPatch, ContentToPatch, DocumentToPatch.

Информационная подготовка к удалению устаревшей логики на облачные подписания