### PR TITLE
DDCORE-9577 Неправильное использование методов апи

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ru.kontur.diadoc</groupId>
     <artifactId>diadocsdk</artifactId>
-    <version>3.23.2</version>
+    <version>3.24.2</version>
 
     <packaging>jar</packaging>
 

--- a/src/main/java/Diadoc/Api/organizations/OrganizationClient.java
+++ b/src/main/java/Diadoc/Api/organizations/OrganizationClient.java
@@ -264,7 +264,7 @@ public class OrganizationClient {
         try {
             var request = RequestBuilder.post(
                     new URIBuilder(diadocHttpClient.getBaseUrl())
-                            .setPath("/Register")
+                            .setPath("/RegisterConfirm")
                             .build())
                     .setEntity(new ByteArrayEntity(registrationConfirmRequest.toByteArray()));
             diadocHttpClient.performRequest(request);

--- a/src/main/java/Diadoc/Api/powersOfAttorney/PowerOfAttorneyClient.java
+++ b/src/main/java/Diadoc/Api/powersOfAttorney/PowerOfAttorneyClient.java
@@ -87,7 +87,7 @@ public class PowerOfAttorneyClient {
         try {
             var request = RequestBuilder.post(
                             new URIBuilder(diadocHttpClient.getBaseUrl())
-                                    .setPath("/RegisterPowerOfAttorneyResult")
+                                    .setPath("/PrevalidatePowerOfAttorney")
                                     .addParameter("boxId", boxId)
                                     .addParameter("registrationNumber", registrationNumber)
                                     .addParameter("issuerInn", issuerInn)


### PR DESCRIPTION
в клиенте [getOrganizationFeatures](https://github.com/diadoc/diadocsdk-java/blob/master/src/main/java/Diadoc/Api/organizations/OrganizationClient.java#L245) используется метод **[/Register ](https://developer.kontur.ru/Docs/diadoc-api/http/Register.html)**вместо [/RegisterConfirm](https://developer.kontur.ru/Docs/diadoc-api/http/RegisterConfirm.html)
- в клиенте [prevalidatePowerOfAttorney](https://github.com/diadoc/diadocsdk-java/blob/master/src/main/java/Diadoc/Api/powersOfAttorney/PowerOfAttorneyClient.java#L69) используется **[/RegisterPowerOfAttorney ](https://developer.kontur.ru/Docs/diadoc-api/http/RegisterPowerOfAttorney.html)**вместо [/PrevalidatePowerOfAttorney](https://developer.kontur.ru/Docs/diadoc-api/http/PrevalidatePowerOfAttorney.html)