### PR TITLE
Исправление багов и добавление недостающих параметров в методы

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -73,7 +73,7 @@ jobs:
 
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: packages
           path: |
@@ -92,7 +92,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: packages
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ru.kontur.diadoc</groupId>
     <artifactId>diadocsdk</artifactId>
-    <version>3.24.2</version>
+    <version>3.24.3</version>
 
     <packaging>jar</packaging>
 

--- a/src/main/java/Diadoc/Api/DiadocApi.java
+++ b/src/main/java/Diadoc/Api/DiadocApi.java
@@ -166,8 +166,25 @@ public class DiadocApi {
         return employeePowerOfAttorneyClient;
     }
 
+    /**
+     * @deprecated
+     * Используйте {@link #getDocumentWorkflowClient()}
+     */
+    @Deprecated
     public DocumentWorkflowClient gDocumentWorkflowClient() {
         return documentWorkflowClient;
+    }
+
+    public TemplateClient getTemplateClient() {
+        return templateClient;
+    }
+
+    public DocumentWorkflowClient getDocumentWorkflowClient() {
+        return documentWorkflowClient;
+    }
+
+    public DiadocHttpClient getDiadocHttpClient() {
+        return diadocHttpClient;
     }
 
     public AuthManager getAuthManager() {

--- a/src/main/java/Diadoc/Api/counteragent/CounteragentClient.java
+++ b/src/main/java/Diadoc/Api/counteragent/CounteragentClient.java
@@ -11,6 +11,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Optional;
 
 import static Diadoc.Api.Proto.AcquireCounteragentProtos.*;
 import static Diadoc.Api.Proto.AsyncMethodResultProtos.*;
@@ -55,10 +57,8 @@ public class CounteragentClient {
                     .setPath("/V2/AcquireCounteragent")
                     .addParameter("myOrgId", myOrgId);
 
-            if (myDepartmentId != null) {
-                url.addParameter("myDepartmentId", myDepartmentId);
-            }
-
+            Tools.addParameterIfNotNull(url, "myDepartmentId", myDepartmentId);
+            
             var request = RequestBuilder
                     .post(url.build())
                     .setEntity(new ByteArrayEntity(acquireCounteragentRequest.toByteArray()));
@@ -86,9 +86,7 @@ public class CounteragentClient {
                     .setPath("/V3/AcquireCounteragent")
                     .addParameter("myBoxId", myBoxId);
 
-            if (myDepartmentId != null) {
-                url.addParameter("myDepartmentId", myDepartmentId);
-            }
+            Tools.addParameterIfNotNull(url, "myDepartmentId", myDepartmentId);
 
             var request = RequestBuilder
                     .post(url.build())
@@ -235,9 +233,7 @@ public class CounteragentClient {
                 url.addParameter("counteragentStatus", counteragentStatus);
             }
 
-            if (afterIndexKey != null) {
-                url.addParameter("afterIndexKey", afterIndexKey);
-            }
+            Tools.addParameterIfNotNull(url, "afterIndexKey", afterIndexKey);
 
             var request = RequestBuilder.get(url.build());
             return CounteragentList.parseFrom(diadocHttpClient.performRequest(request));
@@ -245,23 +241,30 @@ public class CounteragentClient {
             throw new DiadocSdkException(e);
         }
     }
-    
+
     public CounteragentList getCounteragentsV3(String myBoxId, @Nullable String counteragentStatus, @Nullable String afterIndexKey) throws DiadocSdkException {
+        if (Tools.isNullOrEmpty(myBoxId)) {
+            throw new IllegalArgumentException("myBoxId");        }
+
+        var counteragentEnumStatus = CounteragentStatus.fromString(counteragentStatus).orElse(null);
+
+        return getCounteragentsV3(myBoxId, counteragentEnumStatus, afterIndexKey, null, null);
+    }
+
+    public CounteragentList getCounteragentsV3(String myBoxId, @Nullable CounteragentStatus counteragentStatus, @Nullable String afterIndexKey, @Nullable String query, @Nullable Integer pageSize) throws DiadocSdkException {
         if (Tools.isNullOrEmpty(myBoxId)) {
             throw new IllegalArgumentException("myBoxId");
         }
+
         try {
             var url = new URIBuilder(diadocHttpClient.getBaseUrl())
                     .setPath("/V3/GetCounteragents")
                     .addParameter("myBoxId", myBoxId);
 
-            if (!Tools.isNullOrEmpty(counteragentStatus)) {
-                url.addParameter("counteragentStatus", counteragentStatus);
-            }
-
-            if (afterIndexKey != null) {
-                url.addParameter("afterIndexKey", afterIndexKey);
-            }
+            Tools.addParameterIfNotNull(url, "counteragentStatus", counteragentStatus);
+            Tools.addParameterIfNotNull(url, "afterIndexKey", afterIndexKey);
+            Tools.addParameterIfNotNull(url, "query", query);
+            Tools.addParameterIfNotNull(url, "pageSize",pageSize);
 
             var request = RequestBuilder.get(url.build());
             return CounteragentList.parseFrom(diadocHttpClient.performRequest(request));

--- a/src/main/java/Diadoc/Api/counteragent/CounteragentStatus.java
+++ b/src/main/java/Diadoc/Api/counteragent/CounteragentStatus.java
@@ -1,0 +1,20 @@
+package Diadoc.Api.counteragent;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum CounteragentStatus {
+    IsMyCounteragent,
+    InvitesMe,
+    IsInvitedByMe,
+    Rejected;
+
+    public static Optional<CounteragentStatus> fromString(String value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        return Arrays.stream(values())
+                .filter(status -> status.name().equals(value))
+                .findFirst();
+    }
+}

--- a/src/main/java/Diadoc/Api/document/DocumentClient.java
+++ b/src/main/java/Diadoc/Api/document/DocumentClient.java
@@ -6,6 +6,7 @@ import Diadoc.Api.httpClient.DiadocHttpClient;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ByteArrayEntity;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -19,7 +20,7 @@ import static Diadoc.Api.Proto.Events.DiadocMessage_PostApiProtos.PrepareDocumen
 import static Diadoc.Api.Proto.SignatureInfoProtos.SignatureInfo;
 
 public class DocumentClient {
-    private DiadocHttpClient diadocHttpClient;
+    private final DiadocHttpClient diadocHttpClient;
 
     public DocumentClient(DiadocHttpClient diadocHttpClient) {
         this.diadocHttpClient = diadocHttpClient;
@@ -79,6 +80,9 @@ public class DocumentClient {
                 url.addParameter("count", filter.getCount().toString());
             }
 
+            Tools.addParameterIfNotNull(url, "fromDepartmentId", filter.getFromDepartmentId());
+            Tools.addParameterIfNotNull(url, "toDepartmentId", filter.getToDepartmentId());
+
             var request = RequestBuilder.get(url.build());
 
             return DocumentList.parseFrom(diadocHttpClient.performRequest(request));
@@ -99,18 +103,19 @@ public class DocumentClient {
             boolean excludeSubdepartments,
             String afterIndexKey,
             Integer count) throws DiadocSdkException {
-        return getDocuments(new DocumentsFilter()
-                .setBoxId(boxId)
-                .setFilterCategory(filterCategory)
-                .setCounteragentBoxId(counteragentBoxId)
-                .setTimestampFrom(timestampFrom)
-                .setTimestampTo(timestampTo)
-                .setFromDocumentDate(fromDocumentDate)
-                .setToDocumentDate(toDocumentDate)
-                .setDepartmentId(departmentId)
-                .setExcludeSubdepartments(excludeSubdepartments)
-                .setAfterIndexKey(afterIndexKey)
-                .setCount(count));
+        return getDocuments(new DocumentsFilter.Builder()
+                .boxId(boxId)
+                .filterCategory(filterCategory)
+                .counteragentBoxId(counteragentBoxId)
+                .timestampFrom(timestampFrom)
+                .timestampTo(timestampTo)
+                .fromDocumentDate(fromDocumentDate)
+                .toDocumentDate(toDocumentDate)
+                .departmentId(departmentId)
+                .excludeSubdepartments(excludeSubdepartments)
+                .afterIndexKey(afterIndexKey)
+                .count(count)
+                .build());
     }
 
     public DocumentList getDocuments(String boxId,
@@ -148,14 +153,30 @@ public class DocumentClient {
             throw new IllegalArgumentException("entityId");
         }
 
+        return getDocument(boxId, messageId, entityId, true);
+    }
+
+
+    public Document getDocument(String boxId, String messageId, String entityId, @Nullable Boolean injectEntityContent) throws DiadocSdkException {
+        if (boxId == null) {
+            throw new IllegalArgumentException("boxId");
+        }
+        if (messageId == null) {
+            throw new IllegalArgumentException("messageId");
+        }
+        if (entityId == null) {
+            throw new IllegalArgumentException("entityId");
+        }
+
         try {
-            var request = RequestBuilder.get(
-                    new URIBuilder(diadocHttpClient.getBaseUrl())
+            var url = new URIBuilder(diadocHttpClient.getBaseUrl())
                             .setPath("/V3/GetDocument")
                             .addParameter("boxId", boxId)
                             .addParameter("messageId", messageId)
-                            .addParameter("entityId", entityId)
-                            .build());
+                            .addParameter("entityId", entityId);
+            Tools.addParameterIfNotNull(url, "injectEntityContent", injectEntityContent);
+
+            var request = RequestBuilder.get(url.build());
             return Document.parseFrom(diadocHttpClient.performRequest(request));
         } catch (URISyntaxException | IOException e) {
             throw new DiadocSdkException(e);
@@ -203,11 +224,24 @@ public class DocumentClient {
             throw new IllegalArgumentException("documentsToSignRequest");
         }
 
+        return prepareDocumentsToSign(documentsToSignRequest, null);
+    }
+
+    public PrepareDocumentsToSignResponse prepareDocumentsToSign(PrepareDocumentsToSignRequest documentsToSignRequest, @Nullable Boolean excludeContent) throws DiadocSdkException {
+        if (documentsToSignRequest == null) {
+            throw new IllegalArgumentException("documentsToSignRequest");
+        }
+
+        if (excludeContent == null) {
+            excludeContent = false;
+        }
+
         try {
             var request = RequestBuilder.post(
-                    new URIBuilder(diadocHttpClient.getBaseUrl())
-                            .setPath("/PrepareDocumentsToSign")
-                            .build())
+                            new URIBuilder(diadocHttpClient.getBaseUrl())
+                                    .setPath("/PrepareDocumentsToSign")
+                                    .addParameter("excludeContent", excludeContent.toString())
+                                    .build())
                     .setEntity(new ByteArrayEntity(documentsToSignRequest.toByteArray()));
             return PrepareDocumentsToSignResponse.parseFrom(diadocHttpClient.performRequest(request));
         } catch (URISyntaxException | IOException e) {

--- a/src/main/java/Diadoc/Api/document/DocumentsFilter.java
+++ b/src/main/java/Diadoc/Api/document/DocumentsFilter.java
@@ -1,12 +1,14 @@
 package Diadoc.Api.document;
 
-import javax.swing.text.DocumentFilter;
 import java.util.Date;
 
 public class DocumentsFilter {
     private String boxId;
     private String filterCategory;
     private String counteragentBoxId;
+
+    private String fromDepartmentId;
+    private String toDepartmentId;
     private Date timestampFrom;
     private Date timestampTo;
     private String fromDocumentDate;
@@ -17,8 +19,18 @@ public class DocumentsFilter {
     private String afterIndexKey;
     private Integer count;
 
+    /**
+     * @deprecated Конструктор устарел
+     * Рекомендуется использовать {@link #DocumentsFilter(Builder)}
+     */
+    @Deprecated
     public DocumentsFilter(){}
 
+    /**
+     * @deprecated Конструктор устарел
+     * Рекомендуется использовать {@link #DocumentsFilter(Builder)}
+     */
+    @Deprecated
     public DocumentsFilter(
             String boxId,
             String filterCategory,
@@ -46,10 +58,124 @@ public class DocumentsFilter {
         this.count = count;
     }
 
+    private DocumentsFilter(Builder builder) {
+        this.boxId = builder.boxId;
+        this.filterCategory = builder.filterCategory;
+        this.counteragentBoxId = builder.counteragentBoxId;
+        this.timestampFrom = builder.timestampFrom;
+        this.timestampTo = builder.timestampTo;
+        this.fromDocumentDate = builder.fromDocumentDate;
+        this.toDocumentDate = builder.toDocumentDate;
+        this.departmentId = builder.departmentId;
+        this.excludeSubdepartments = builder.excludeSubdepartments;
+        this.sortDirection = builder.sortDirection;
+        this.afterIndexKey = builder.afterIndexKey;
+        this.count = builder.count;
+        this.fromDepartmentId = builder.fromDepartmentId;
+        this.toDepartmentId = builder.toDepartmentId;
+    }
+
+    public static class Builder {
+        private String boxId;
+        private String filterCategory;
+        private String counteragentBoxId;
+        private String fromDepartmentId;
+        private String toDepartmentId;
+        private Date timestampFrom;
+        private Date timestampTo;
+        private String fromDocumentDate;
+        private String toDocumentDate;
+        private String departmentId;
+        private boolean excludeSubdepartments;
+        private String sortDirection;
+        private String afterIndexKey;
+        private Integer count;
+
+        public Builder() {}
+
+        public Builder boxId(String boxId) {
+            this.boxId = boxId;
+            return this;
+        }
+
+        public Builder filterCategory(String filterCategory) {
+            this.filterCategory = filterCategory;
+            return this;
+        }
+
+        public Builder counteragentBoxId(String counteragentBoxId) {
+            this.counteragentBoxId = counteragentBoxId;
+            return this;
+        }
+
+        public Builder timestampFrom(Date timestampFrom) {
+            this.timestampFrom = timestampFrom;
+            return this;
+        }
+
+        public Builder timestampTo(Date timestampTo) {
+            this.timestampTo = timestampTo;
+            return this;
+        }
+
+        public Builder fromDocumentDate(String fromDocumentDate) {
+            this.fromDocumentDate = fromDocumentDate;
+            return this;
+        }
+
+        public Builder toDocumentDate(String toDocumentDate) {
+            this.toDocumentDate = toDocumentDate;
+            return this;
+        }
+
+        public Builder departmentId(String departmentId) {
+            this.departmentId = departmentId;
+            return this;
+        }
+
+        public Builder excludeSubdepartments(boolean excludeSubdepartments) {
+            this.excludeSubdepartments = excludeSubdepartments;
+            return this;
+        }
+
+        public Builder sortDirection(String sortDirection) {
+            this.sortDirection = sortDirection;
+            return this;
+        }
+
+        public Builder afterIndexKey(String afterIndexKey) {
+            this.afterIndexKey = afterIndexKey;
+            return this;
+        }
+
+        public Builder count(Integer count) {
+            this.count = count;
+            return this;
+        }
+
+        public Builder fromDepartmentId(String fromDepartmentId) {
+            this.fromDepartmentId = fromDepartmentId;
+            return this;
+        }
+
+        public Builder toDepartmentId(String toDepartmentId) {
+            this.toDepartmentId = toDepartmentId;
+            return this;
+        }
+
+        public DocumentsFilter build() {
+            return new DocumentsFilter(this);
+        }
+    }
+
     public String getBoxId() {
         return boxId;
     }
 
+    /**
+     * @deprecated Setter устарел
+     * Рекомендуется использовать {@link #DocumentsFilter(Builder)}
+     */
     public DocumentsFilter setBoxId(String boxId) {
         this.boxId = boxId;
         return this;
@@ -59,6 +185,10 @@ public class DocumentsFilter {
         return filterCategory;
     }
 
+    /**
+     * @deprecated Setter устарел
+     * Рекомендуется использовать {@link #DocumentsFilter(Builder)}
+     */
     public DocumentsFilter setFilterCategory(String filterCategory) {
         this.filterCategory = filterCategory;
         return this;
@@ -68,6 +198,10 @@ public class DocumentsFilter {
         return counteragentBoxId;
     }
 
+    /**
+     * @deprecated Setter устарел
+     * Рекомендуется использовать {@link #DocumentsFilter(Builder)}
+     */
     public DocumentsFilter setCounteragentBoxId(String counteragentBoxId) {
         this.counteragentBoxId = counteragentBoxId;
         return this;
@@ -77,6 +211,10 @@ public class DocumentsFilter {
         return timestampFrom;
     }
 
+    /**
+     * @deprecated Setter устарел
+     * Рекомендуется использовать {@link #DocumentsFilter(Builder)}
+     */
     public DocumentsFilter setTimestampFrom(Date timestampFrom) {
         this.timestampFrom = timestampFrom;
         return this;
@@ -86,6 +224,10 @@ public class DocumentsFilter {
         return timestampTo;
     }
 
+    /**
+     * @deprecated Setter устарел
+     * Рекомендуется использовать {@link #DocumentsFilter(Builder)}
+     */
     public DocumentsFilter setTimestampTo(Date timestampTo) {
         this.timestampTo = timestampTo;
         return this;
@@ -95,6 +237,10 @@ public class DocumentsFilter {
         return fromDocumentDate;
     }
 
+    /**
+     * @deprecated Setter устарел
+     * Рекомендуется использовать {@link #DocumentsFilter(Builder)}
+     */
     public DocumentsFilter setFromDocumentDate(String fromDocumentDate) {
         this.fromDocumentDate = fromDocumentDate;
         return this;
@@ -104,6 +250,10 @@ public class DocumentsFilter {
         return toDocumentDate;
     }
 
+    /**
+     * @deprecated Setter устарел
+     * Рекомендуется использовать {@link #DocumentsFilter(Builder)}
+     */
     public DocumentsFilter setToDocumentDate(String toDocumentDate) {
         this.toDocumentDate = toDocumentDate;
         return this;
@@ -113,6 +263,10 @@ public class DocumentsFilter {
         return departmentId;
     }
 
+    /**
+     * @deprecated Setter устарел
+     * Рекомендуется использовать {@link #DocumentsFilter(Builder)}
+     */
     public DocumentsFilter setDepartmentId(String departmentId) {
         this.departmentId = departmentId;
         return this;
@@ -122,6 +276,10 @@ public class DocumentsFilter {
         return excludeSubdepartments;
     }
 
+    /**
+     * @deprecated Setter устарел
+     * Рекомендуется использовать {@link #DocumentsFilter(Builder)}
+     */
     public DocumentsFilter setExcludeSubdepartments(boolean excludeSubdepartments) {
         this.excludeSubdepartments = excludeSubdepartments;
         return this;
@@ -131,6 +289,10 @@ public class DocumentsFilter {
         return sortDirection;
     }
 
+    /**
+     * @deprecated Setter устарел
+     * Рекомендуется использовать {@link #DocumentsFilter(Builder)}
+     */
     public DocumentsFilter setSortDirection(String sortDirection) {
         this.sortDirection = sortDirection;
         return this;
@@ -140,6 +302,10 @@ public class DocumentsFilter {
         return afterIndexKey;
     }
 
+    /**
+     * @deprecated Setter устарел
+     * Рекомендуется использовать {@link #DocumentsFilter(Builder)}
+     */
     public DocumentsFilter setAfterIndexKey(String afterIndexKey) {
         this.afterIndexKey = afterIndexKey;
         return this;
@@ -149,8 +315,20 @@ public class DocumentsFilter {
         return count;
     }
 
+    /**
+     * @deprecated Setter устарел
+     * Рекомендуется использовать {@link #DocumentsFilter(Builder)}
+     */
     public DocumentsFilter setCount(Integer count) {
         this.count = count;
         return this;
+    }
+
+    public String getFromDepartmentId() {
+        return fromDepartmentId;
+    }
+
+    public String getToDepartmentId() {
+        return toDepartmentId;
     }
 }

--- a/src/main/java/Diadoc/Api/helpers/Tools.java
+++ b/src/main/java/Diadoc/Api/helpers/Tools.java
@@ -8,6 +8,7 @@ import java.io.InputStreamReader;
 import java.util.Random;
 
 import com.google.protobuf.ByteString;
+import org.apache.http.client.utils.URIBuilder;
 
 public class Tools {
     public static String ConsoleReadLine() throws IOException {
@@ -51,5 +52,17 @@ public class Tools {
 
     public static String concatUriPath(String prefixPath, String postfixPath) {
         return prefixPath.replaceAll("/*$", "") + postfixPath;
+    }
+
+    public static void addParameterIfNotNull(URIBuilder urlBuilder, String paramName, Object paramValue) {
+        if (paramValue != null) {
+            urlBuilder.addParameter(paramName, String.valueOf(paramValue));
+        }
+    }
+
+    public static void addParameterIfNotNull(URIBuilder urlBuilder, String paramName, Enum<?> paramValue) {
+        if (paramValue != null) {
+            urlBuilder.addParameter(paramName, paramValue.name());
+        }
     }
 }

--- a/src/main/java/Diadoc/Api/powersOfAttorney/PowerOfAttorneyClient.java
+++ b/src/main/java/Diadoc/Api/powersOfAttorney/PowerOfAttorneyClient.java
@@ -87,7 +87,7 @@ public class PowerOfAttorneyClient {
         try {
             var request = RequestBuilder.post(
                             new URIBuilder(diadocHttpClient.getBaseUrl())
-                                    .setPath("/RegisterPowerOfAttorneyResult")
+                                    .setPath("/PrevalidatePowerOfAttorney")
                                     .addParameter("boxId", boxId)
                                     .addParameter("registrationNumber", registrationNumber)
                                     .addParameter("issuerInn", issuerInn)

--- a/src/main/java/Diadoc/Api/print/PrintFormClient.java
+++ b/src/main/java/Diadoc/Api/print/PrintFormClient.java
@@ -1,6 +1,7 @@
 package Diadoc.Api.print;
 
 import Diadoc.Api.exceptions.DiadocSdkException;
+import Diadoc.Api.httpClient.DiadocResponseInfo;
 import Diadoc.Api.print.models.DocumentProtocolResult;
 import Diadoc.Api.print.models.DocumentZipResult;
 import Diadoc.Api.print.models.PrintFormContent;
@@ -14,6 +15,7 @@ import org.apache.http.entity.ByteArrayEntity;
 import javax.mail.internet.ParseException;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 
 import static Diadoc.Api.Proto.CustomPrintFormDetectionProtos.*;
 import static Diadoc.Api.Proto.Documents.DocumentProtocolProtos.*;
@@ -145,31 +147,46 @@ public class PrintFormClient {
     }
 
     public PrintFormResult generatePrintFormFromAttachment(String fromBoxId, String documentType, byte[] bytes) throws DiadocSdkException {
-        if (Tools.isNullOrEmpty(fromBoxId)) {
-            throw new IllegalArgumentException("fromBoxId");
-        }
+        validateInput(documentType, bytes);
+
+        var response = executeGeneratePrintFormRequest(fromBoxId, documentType, bytes);
+
+        return new PrintFormResult(
+                new PrintFormContent(
+                        response.getContentType(),
+                        response.getFileName() != null ? response.getFileName() : "default",
+                        response.getContent()
+                )
+        );
+    }
+
+    public String generatePrintFormFromAttachmentId(String fromBoxId, String documentType, byte[] bytes) throws DiadocSdkException {
+        validateInput(documentType, bytes);
+
+        var response = executeGeneratePrintFormRequest(fromBoxId, documentType, bytes).getContent();
+
+        return new String(response, StandardCharsets.UTF_8);
+    }
+
+    private void validateInput(String documentType, byte[] bytes) {
         if (Tools.isNullOrEmpty(documentType)) {
             throw new IllegalArgumentException("documentType");
         }
         if (bytes == null) {
             throw new IllegalArgumentException("bytes");
         }
+    }
 
+    private DiadocResponseInfo executeGeneratePrintFormRequest(String fromBoxId, String documentType, byte[] bytes) throws DiadocSdkException {
         try {
-            var request = RequestBuilder.get(new URIBuilder(diadocHttpClient.getBaseUrl())
+            var uri = new URIBuilder(diadocHttpClient.getBaseUrl())
                     .setPath("/GeneratePrintFormFromAttachment")
-                    .addParameter("fromBoxId", fromBoxId)
-                    .addParameter("documentType", documentType)
-                    .build())
-                    .setEntity(new ByteArrayEntity(bytes));
+                    .addParameter("documentType", documentType);
+            Tools.addParameterIfNotNull(uri, "fromBoxId", fromBoxId);
 
-            var response = diadocHttpClient.getRawResponse(request);
+            var request = RequestBuilder.post(uri.build()).setEntity(new ByteArrayEntity(bytes));
 
-            if (response.getRetryAfter() != null) {
-                return new PrintFormResult(response.getRetryAfter());
-            }
-
-            return new PrintFormResult(new PrintFormContent(response.getContentType(), response.getFileName(), response.getContent()));
+            return diadocHttpClient.getRawResponse(request);
 
         } catch (URISyntaxException | ParseException | IOException e) {
             throw new DiadocSdkException(e);

--- a/src/main/java/Diadoc/Api/template/TemplateClient.java
+++ b/src/main/java/Diadoc/Api/template/TemplateClient.java
@@ -93,6 +93,15 @@ public class TemplateClient {
             String templateId,
             DiadocMessage_PostApiProtos.TemplatePatchToPost templatePatchToPost) throws DiadocSdkException {
 
+        return postTemplatePatch(boxId, templateId, null, templatePatchToPost);
+    }
+
+    public MessagePatch postTemplatePatch(
+            String boxId,
+            String templateId,
+            @Nullable String operationId,
+            DiadocMessage_PostApiProtos.TemplatePatchToPost templatePatchToPost) throws DiadocSdkException {
+
         if (boxId == null) {
             throw new IllegalArgumentException("boxId");
         }
@@ -104,12 +113,12 @@ public class TemplateClient {
         }
 
         try {
-            var request = RequestBuilder.post(
-                    new URIBuilder(diadocHttpClient.getBaseUrl())
-                            .setPath("/PostTemplatePatch")
-                            .addParameter("boxId", boxId)
-                            .addParameter("templateId", templateId)
-                            .build())
+            var url = new URIBuilder(diadocHttpClient.getBaseUrl())
+                    .setPath("/PostTemplatePatch")
+                    .addParameter("boxId", boxId)
+                    .addParameter("templateId", templateId);
+            Tools.addParameterIfNotNull(url, "operationId", operationId);
+            var request = RequestBuilder.post(url.build())
                     .setEntity(new ByteArrayEntity(templatePatchToPost.toByteArray()));
 
             return MessagePatch.parseFrom(diadocHttpClient.performRequest(request));


### PR DESCRIPTION
в /PostTemplatePatch добавлен operationId
Исправлены баги в клиентах: 
    - [getOrganizationFeatures](https://github.com/diadoc/diadocsdk-java/blob/master/src/main/java/Diadoc/Api/organizations/OrganizationClient.java#L245) используется метод **[/Register ](https://developer.kontur.ru/Docs/diadoc-api/http/Register.html) вместо [/RegisterConfirm](https://developer.kontur.ru/Docs/diadoc-api/http/RegisterConfirm.html)
    - [prevalidatePowerOfAttorney](https://github.com/diadoc/diadocsdk-java/blob/master/src/main/java/Diadoc/Api/powersOfAttorney/PowerOfAttorneyClient.java#L69) используется[/RegisterPowerOfAttorney ](https://developer.kontur.ru/Docs/diadoc-api/http/RegisterPowerOfAttorney.html) вместо [/PrevalidatePowerOfAttorney](https://developer.kontur.ru/Docs/diadoc-api/http/PrevalidatePowerOfAttorney.html)
  - /PrepareDocumentsToSign добавлен excludeContent
  
  - убрана логика с Retry-After в generatePrintFormFromAttachment и добавлен перегруженный метод, возвращающий идентификатор напрямую; параметр fromBoxId сделан опциональным, тк он необязательный
  
  -  в /GetDocument добавлен injectEntityContent
  -  в /GetDocuments добавлены fromDepartmentId, toDepartmentId, documentNumber
  - в /GetCounteragents добавлены query и pageSize
  
  Полный перечень поддерживаемых параметров в /[GetOrganization](https://developer.kontur.ru/docs/diadoc-api/http/GetOrganization.html?highlight=getorganization)