### PR TITLE
DDCORE-9578 Исправление багов на опциональные параметры в GenerateClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ru.kontur.diadoc</groupId>
     <artifactId>diadocsdk</artifactId>
-    <version>3.25.0</version>
+    <version>3.25.1</version>
 
     <packaging>jar</packaging>
 
@@ -26,7 +26,7 @@
 
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
-        <protobuf-maven-plugin.version>0.5.1</protobuf-maven-plugin.version>
+        <protobuf-maven-plugin.version>0.5.0</protobuf-maven-plugin.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/Diadoc/Api/document/DocumentClient.java
+++ b/src/main/java/Diadoc/Api/document/DocumentClient.java
@@ -351,7 +351,7 @@ public class DocumentClient {
         }
     }
 
-    public byte[] getForwardedEntityContent(String boxId, ForwardedDocumentProtos.ForwardedDocumentId forwardedDocumentId) throws DiadocSdkException {
+    public byte[] getForwardedEntityContent(String boxId, ForwardedDocumentProtos.ForwardedDocumentId forwardedDocumentId, String entityId) throws DiadocSdkException {
         if (boxId == null) {
             throw new IllegalArgumentException("boxId");
         }
@@ -360,13 +360,18 @@ public class DocumentClient {
             throw new IllegalArgumentException("forwardedDocumentId");
         }
 
+        if (entityId == null) {
+            throw new IllegalArgumentException("entityId");
+        }
+
         try {
             var url = new URIBuilder(diadocHttpClient.getBaseUrl())
                     .setPath("/V2/GetForwardedEntityContent")
                     .addParameter("boxId", boxId)
-                    .build();
-            var request = RequestBuilder.post(url)
-                    .setEntity(new ByteArrayEntity(forwardedDocumentId.toByteArray()));
+                    .addParameter("entityId", entityId)
+                    .addParameters(getForwardedDocumentIdParameters(forwardedDocumentId));
+
+            var request = RequestBuilder.get(url.build());
 
             return diadocHttpClient.performRequest(request);
         } catch (URISyntaxException | IOException e) {

--- a/src/main/java/Diadoc/Api/generateTitle/GenerateClient.java
+++ b/src/main/java/Diadoc/Api/generateTitle/GenerateClient.java
@@ -2,6 +2,7 @@ package Diadoc.Api.generateTitle;
 
 import Diadoc.Api.Proto.Invoicing.TovTorgInfoProtos;
 import Diadoc.Api.exceptions.DiadocSdkException;
+import Diadoc.Api.helpers.Tools;
 import Diadoc.Api.httpClient.DiadocHttpClient;
 import Diadoc.Api.httpClient.GeneratedFile;
 import com.google.protobuf.GeneratedMessage;
@@ -79,9 +80,7 @@ public class GenerateClient {
                 .addParameter("boxId", boxId)
                 .addParameter("messageId", messageId)
                 .addParameter("attachmentId", attachmentId);
-            if(contentTypeId != null) {
-                uriBuilder.addParameter("contentTypeId", contentTypeId);
-            }
+            Tools.addParameterIfNotNull(uriBuilder,  "contentTypeId", contentTypeId);
             var request = RequestBuilder.post(uriBuilder.build())
                     .setEntity(new ByteArrayEntity(revocationRequestInfo.toByteArray()));
             return diadocHttpClient.performRequestWithGeneratedFile(request);
@@ -199,13 +198,10 @@ public class GenerateClient {
             throw new IllegalArgumentException("info");
         }
         try {
-
-            var request = RequestBuilder.post(
-                    new URIBuilder(diadocHttpClient.getBaseUrl())
-                            .setPath("/GenerateInvoiceXml")
-                            .addParameter("invoiceType", invoiceType)
-                            .addParameter("disableValidation", String.valueOf(disableValidation)).build())
-                    .setEntity(new ByteArrayEntity(invoiceInfo.toByteArray()));
+            var uri =   new URIBuilder(diadocHttpClient.getBaseUrl()).setPath("/GenerateInvoiceXml");
+            Tools.addParameterIfNotNull(uri, "invoiceType", invoiceType);
+            Tools.addParameterIfNotNull(uri, "disableValidation", disableValidation);
+            var request = RequestBuilder.post(uri.build()).setEntity(new ByteArrayEntity(invoiceInfo.toByteArray()));
             return diadocHttpClient.performRequestWithGeneratedFile(request);
         } catch (URISyntaxException | IOException | ParseException e) {
             throw new DiadocSdkException(e);
@@ -223,6 +219,39 @@ public class GenerateClient {
             boolean disableValidation,
             @Nullable String letterId,
             @Nullable String documentId) throws DiadocSdkException {
+        checkDocumentParameters(boxId, documentTypeNamedId, documentFunction, documentVersion, userContractData);
+
+        if (titleIndex == null) {
+            throw new IllegalArgumentException("titleIndex");
+        }
+
+        if (titleIndex > 0 && documentId == null) {
+            throw new IllegalArgumentException("documentId");
+        }
+
+        try {
+            var uri = new URIBuilder(diadocHttpClient.getBaseUrl())
+                    .setPath("/GenerateTitleXml")
+                    .addParameter("boxId", boxId)
+                    .addParameter("documentTypeNamedId", documentTypeNamedId)
+                    .addParameter("documentFunction", documentFunction)
+                    .addParameter("documentVersion", documentVersion)
+                    .addParameter("titleIndex", String.valueOf(titleIndex));
+
+            Tools.addParameterIfNotNull(uri, "editingSettingId", editingSettingId);
+            Tools.addParameterIfNotNull(uri, "disableValidation", disableValidation);
+            Tools.addParameterIfNotNull(uri, "letterId", letterId);
+            Tools.addParameterIfNotNull(uri, "documentId", documentId);
+
+
+            var request = RequestBuilder.post(uri.build()).setEntity(new ByteArrayEntity(userContractData));
+            return diadocHttpClient.performRequestWithGeneratedFile(request);
+        } catch (URISyntaxException | IOException | ParseException e) {
+            throw new DiadocSdkException(e);
+        }
+    }
+
+    private void checkDocumentParameters(String boxId, String documentTypeNamedId, String documentFunction, String documentVersion, byte[] userContractData) {
         if (boxId == null) {
             throw new IllegalArgumentException("boxId");
         }
@@ -237,25 +266,6 @@ public class GenerateClient {
         }
         if (userContractData == null) {
             throw new IllegalArgumentException("userContractData");
-        }
-
-        try {
-            var request = RequestBuilder.post(
-                    new URIBuilder(diadocHttpClient.getBaseUrl())
-                            .setPath("/GenerateTitleXml")
-                            .addParameter("boxId", boxId)
-                            .addParameter("documentTypeNamedId", documentTypeNamedId)
-                            .addParameter("documentFunction", documentFunction)
-                            .addParameter("documentVersion", documentVersion)
-                            .addParameter("titleIndex", titleIndex.toString())
-                            .addParameter("disableValidation", Boolean.toString(disableValidation))
-                            .addParameter("editingSettingId", editingSettingId)
-                            .addParameter("letterId", letterId)
-                            .addParameter("documentId", documentId).build())
-                    .setEntity(new ByteArrayEntity(userContractData));
-            return diadocHttpClient.performRequestWithGeneratedFile(request);
-        } catch (URISyntaxException | IOException | ParseException e) {
-            throw new DiadocSdkException(e);
         }
     }
 
@@ -311,34 +321,18 @@ public class GenerateClient {
             byte[] userContractData,
             @Nullable String editingSettingId,
             boolean disableValidation) throws DiadocSdkException {
-        if (boxId == null) {
-            throw new IllegalArgumentException("boxId");
-        }
-        if (documentTypeNamedId == null) {
-            throw new IllegalArgumentException("documentTypeNamedId");
-        }
-        if (documentFunction == null) {
-            throw new IllegalArgumentException("documentFunction");
-        }
-        if (documentVersion == null) {
-            throw new IllegalArgumentException("documentVersion");
-        }
-        if (userContractData == null) {
-            throw new IllegalArgumentException("userContractData");
-        }
+        checkDocumentParameters(boxId, documentTypeNamedId, documentFunction, documentVersion, userContractData);
 
         try {
-
-            var request = RequestBuilder.post(
-                    new URIBuilder(diadocHttpClient.getBaseUrl())
-                            .setPath("/GenerateSenderTitleXml")
-                            .addParameter("boxId", boxId)
-                            .addParameter("documentTypeNamedId", documentTypeNamedId)
-                            .addParameter("documentFunction", documentFunction)
-                            .addParameter("documentVersion", documentVersion)
-                            .addParameter("disableValidation", Boolean.toString(disableValidation))
-                            .addParameter("editingSettingId", editingSettingId).build())
-                    .setEntity(new ByteArrayEntity(userContractData));
+            var uri =  new URIBuilder(diadocHttpClient.getBaseUrl())
+                    .setPath("/GenerateSenderTitleXml")
+                    .addParameter("boxId", boxId)
+                    .addParameter("documentTypeNamedId", documentTypeNamedId)
+                    .addParameter("documentFunction", documentFunction)
+                    .addParameter("documentVersion", documentVersion);
+            Tools.addParameterIfNotNull(uri, "disableValidation", disableValidation);
+            Tools.addParameterIfNotNull(uri, "editingSettingId", editingSettingId);
+            var request = RequestBuilder.post(uri.build()).setEntity(new ByteArrayEntity(userContractData));
             return diadocHttpClient.performRequestWithGeneratedFile(request);
         } catch (URISyntaxException | IOException | ParseException e) {
             throw new DiadocSdkException(e);
@@ -379,14 +373,13 @@ public class GenerateClient {
         }
 
         try {
-            var request = RequestBuilder.post(
-                    new URIBuilder(diadocHttpClient.getBaseUrl())
-                            .setPath("/GenerateRecipientTitleXml")
-                            .addParameter("boxId", boxId)
-                            .addParameter("senderTitleMessageId", senderTitleMessageId)
-                            .addParameter("senderTitleAttachmentId", senderTitleAttachmentId)
-                            .addParameter("documentVersion", documentVersion).build())
-                    .setEntity(new ByteArrayEntity(userContractData));
+            var uri =  new URIBuilder(diadocHttpClient.getBaseUrl())
+                    .setPath("/GenerateRecipientTitleXml")
+                    .addParameter("boxId", boxId)
+                    .addParameter("senderTitleMessageId", senderTitleMessageId)
+                    .addParameter("senderTitleAttachmentId", senderTitleAttachmentId);
+            Tools.addParameterIfNotNull(uri, "documentVersion", documentVersion);
+            var request = RequestBuilder.post(uri.build()).setEntity(new ByteArrayEntity(userContractData));
             return diadocHttpClient.performRequestWithGeneratedFile(request);
         } catch (URISyntaxException | IOException | ParseException e) {
             throw new DiadocSdkException(e);
@@ -410,13 +403,10 @@ public class GenerateClient {
             throw new IllegalArgumentException("sellerTitleInfo");
         }
         try {
-            var request = RequestBuilder.post(
-                    new URIBuilder(diadocHttpClient.getBaseUrl())
-                            .setPath("/GenerateTorg12XmlForSeller")
-                            .addParameter("disableValidation", String.valueOf(disableValidation))
-                            .addParameter("documentVersion", documentVersion)
-                            .build())
-                    .setEntity(new ByteArrayEntity(sellerTitleInfo.toByteArray()));
+            var uri = new URIBuilder(diadocHttpClient.getBaseUrl()).setPath("/GenerateTorg12XmlForSeller");
+            Tools.addParameterIfNotNull(uri, "disableValidation", String.valueOf(disableValidation));
+            Tools.addParameterIfNotNull(uri, "documentVersion", documentVersion);
+            var request = RequestBuilder.post(uri.build()).setEntity(new ByteArrayEntity(sellerTitleInfo.toByteArray()));
             return diadocHttpClient.performRequestWithGeneratedFile(request);
         } catch (URISyntaxException | IOException | ParseException e) {
             throw new DiadocSdkException(e);
@@ -474,29 +464,16 @@ public class GenerateClient {
             String sellerTitleMessageId,
             String sellerTitleAttachmentId,
             @Nullable String documentVersion) throws DiadocSdkException {
-        if (buyerTitleInfo == null) {
-            throw new IllegalArgumentException("buyerTitleInfo");
-        }
-        if (boxId == null) {
-            throw new IllegalArgumentException("boxId");
-        }
-        if (sellerTitleMessageId == null) {
-            throw new IllegalArgumentException("sellerTitleMessageId");
-        }
-        if (sellerTitleAttachmentId == null) {
-            throw new IllegalArgumentException("sellerTitleAttachmentId");
-        }
+        checkParameters(buyerTitleInfo, boxId, sellerTitleMessageId, sellerTitleAttachmentId);
 
         try {
-            var request = RequestBuilder.post(
-                    new URIBuilder(diadocHttpClient.getBaseUrl())
-                            .setPath("/GenerateTorg12XmlForBuyer")
-                            .addParameter("boxId", boxId)
-                            .addParameter("sellerTitleMessageId", sellerTitleMessageId)
-                            .addParameter("sellerTitleAttachmentId", sellerTitleAttachmentId)
-                            .addParameter("documentVersion", documentVersion)
-                            .build())
-                    .setEntity(new ByteArrayEntity(buyerTitleInfo.toByteArray()));
+            var uri = new URIBuilder(diadocHttpClient.getBaseUrl())
+                    .setPath("/GenerateTorg12XmlForBuyer")
+                    .addParameter("boxId", boxId)
+                    .addParameter("sellerTitleMessageId", sellerTitleMessageId)
+                    .addParameter("sellerTitleAttachmentId", sellerTitleAttachmentId);
+            Tools.addParameterIfNotNull(uri, "documentVersion", documentVersion);
+            var request = RequestBuilder.post(uri.build()).setEntity(new ByteArrayEntity(buyerTitleInfo.toByteArray()));
             return diadocHttpClient.performRequestWithGeneratedFile(request);
         } catch (URISyntaxException | IOException | ParseException e) {
             throw new DiadocSdkException(e);
@@ -521,18 +498,15 @@ public class GenerateClient {
 
     private <T extends GeneratedMessage> GeneratedFile generateAcceptanceCertificateXmlForSeller(T sellerTitleInfo, boolean disableValidation, @Nullable String documentVersion)
             throws DiadocSdkException {
-
         if (sellerTitleInfo == null) {
             throw new IllegalArgumentException("sellerTitleInfo");
         }
+
         try {
-            var request = RequestBuilder.post(
-                    new URIBuilder(diadocHttpClient.getBaseUrl())
-                            .setPath("/GenerateAcceptanceCertificateXmlForSeller")
-                            .addParameter("disableValidation", String.valueOf(disableValidation))
-                            .addParameter("documentVersion", documentVersion)
-                            .build())
-                    .setEntity(new ByteArrayEntity(sellerTitleInfo.toByteArray()));
+            var uri = new URIBuilder(diadocHttpClient.getBaseUrl()).setPath("/GenerateAcceptanceCertificateXmlForSeller");
+            Tools.addParameterIfNotNull(uri, "documentVersion", documentVersion);
+            Tools.addParameterIfNotNull(uri, "disableValidation", disableValidation);
+            var request = RequestBuilder.post(uri.build()).setEntity(new ByteArrayEntity(sellerTitleInfo.toByteArray()));
             return diadocHttpClient.performRequestWithGeneratedFile(request);
         } catch (URISyntaxException | IOException | ParseException e) {
             throw new DiadocSdkException(e);
@@ -561,6 +535,23 @@ public class GenerateClient {
             String sellerTitleMessageId,
             String sellerTitleAttachmentId,
             @Nullable String documentVersion) throws DiadocSdkException {
+        checkParameters(buyerTitleInfo, boxId, sellerTitleMessageId, sellerTitleAttachmentId);
+        try {
+            var uri = new URIBuilder(diadocHttpClient.getBaseUrl())
+                    .setPath("/GenerateAcceptanceCertificateXmlForBuyer")
+                    .addParameter("boxId", boxId)
+                    .addParameter("sellerTitleMessageId", sellerTitleMessageId)
+                    .addParameter("sellerTitleAttachmentId", sellerTitleAttachmentId);
+
+            Tools.addParameterIfNotNull(uri, "documentVersion", documentVersion);
+            var request = RequestBuilder.post(uri.build()).setEntity(new ByteArrayEntity(buyerTitleInfo.toByteArray()));
+            return diadocHttpClient.performRequestWithGeneratedFile(request);
+        } catch (URISyntaxException | IOException | ParseException e) {
+            throw new DiadocSdkException(e);
+        }
+    }
+
+    private <T extends GeneratedMessage> void checkParameters(T buyerTitleInfo, String boxId, String sellerTitleMessageId, String sellerTitleAttachmentId) {
         if (buyerTitleInfo == null) {
             throw new IllegalArgumentException("buyerTitleInfo");
         }
@@ -572,20 +563,6 @@ public class GenerateClient {
         }
         if (sellerTitleAttachmentId == null) {
             throw new IllegalArgumentException("sellerTitleAttachmentId");
-        }
-        try {
-            var request = RequestBuilder.post(
-                    new URIBuilder(diadocHttpClient.getBaseUrl())
-                            .setPath("/GenerateAcceptanceCertificateXmlForBuyer")
-                            .addParameter("boxId", boxId)
-                            .addParameter("sellerTitleMessageId", sellerTitleMessageId)
-                            .addParameter("sellerTitleAttachmentId", sellerTitleAttachmentId)
-                            .addParameter("documentVersion", documentVersion)
-                            .build())
-                    .setEntity(new ByteArrayEntity(buyerTitleInfo.toByteArray()));
-            return diadocHttpClient.performRequestWithGeneratedFile(request);
-        } catch (URISyntaxException | IOException | ParseException e) {
-            throw new DiadocSdkException(e);
         }
     }
 
@@ -603,13 +580,11 @@ public class GenerateClient {
         }
 
         try {
-            var request = RequestBuilder.post(
-                    new URIBuilder(diadocHttpClient.getBaseUrl())
-                            .setPath("/GenerateUniversalTransferDocumentXmlForSeller")
-                            .addParameter("documentVersion", documentVersion)
-                            .addParameter("disableValidation", String.valueOf(disableValidation))
-                            .build())
-                    .setEntity(new ByteArrayEntity(utdInfo.toByteArray()));
+            var uri = new URIBuilder(diadocHttpClient.getBaseUrl())
+                    .setPath("/GenerateUniversalTransferDocumentXmlForSeller");
+            Tools.addParameterIfNotNull(uri, "documentVersion", documentVersion);
+            Tools.addParameterIfNotNull(uri, "disableValidation", disableValidation);
+            var request = RequestBuilder.post(uri.build()).setEntity(new ByteArrayEntity(utdInfo.toByteArray()));
             return diadocHttpClient.performRequestWithGeneratedFile(request);
         } catch (URISyntaxException | IOException | ParseException e) {
             throw new DiadocSdkException(e);
@@ -622,18 +597,7 @@ public class GenerateClient {
             String sellerTitleMessageId,
             String sellerTitleAttachmentId
     ) throws DiadocSdkException {
-        if (buyerTitleInfo == null) {
-            throw new IllegalArgumentException("buyerTitleInfo");
-        }
-        if (boxId == null) {
-            throw new IllegalArgumentException("boxId");
-        }
-        if (sellerTitleMessageId == null) {
-            throw new IllegalArgumentException("sellerTitleMessageId");
-        }
-        if (sellerTitleAttachmentId == null) {
-            throw new IllegalArgumentException("sellerTitleAttachmentId");
-        }
+        checkParameters(buyerTitleInfo, boxId, sellerTitleMessageId, sellerTitleAttachmentId);
         try {
             var request = RequestBuilder.post(
                     new URIBuilder(diadocHttpClient.getBaseUrl())
@@ -652,25 +616,25 @@ public class GenerateClient {
     public GeneratedFile generateUniversalCorrectionTransferDocumentXmlForSeller(
             UniversalCorrectionDocumentSellerTitleInfo ucdInfo,
             boolean disableValidation,
-            String documentVersion) throws DiadocSdkException {
+            @Nullable String documentVersion) throws DiadocSdkException {
         if (ucdInfo == null) {
             throw new IllegalArgumentException("info");
         }
 
         try {
-            var request = RequestBuilder.post(
-                    new URIBuilder(diadocHttpClient.getBaseUrl())
-                            .setPath("/GenerateUniversalTransferDocumentXmlForSeller")
-                            .addParameter("correction", null)
-                            .addParameter("documentVersion", documentVersion)
-                            .addParameter("disableValidation", String.valueOf(disableValidation))
-                            .build())
-                    .setEntity(new ByteArrayEntity(ucdInfo.toByteArray()));
+            var uri = new URIBuilder(diadocHttpClient.getBaseUrl())
+                    .setPath("/GenerateUniversalTransferDocumentXmlForSeller");
+            Tools.addParameterIfNotNull(uri, "documentVersion", documentVersion);
+            Tools.addParameterIfNotNull(uri, "disableValidation", disableValidation);
+            Tools.addParameterIfNotNull(uri, "correction", true);
+
+            var request = RequestBuilder.post(uri.build()).setEntity(new ByteArrayEntity(ucdInfo.toByteArray()));
             return diadocHttpClient.performRequestWithGeneratedFile(request);
         } catch (URISyntaxException | IOException | ParseException e) {
             throw new DiadocSdkException(e);
         }
     }
+
 
     public GeneratedFile generateUniversalCorrectionTransferDocumentXmlForSeller(UniversalCorrectionDocumentSellerTitleInfo ucdInfo) throws DiadocSdkException {
         return generateUniversalCorrectionTransferDocumentXmlForSeller(ucdInfo, false);


### PR DESCRIPTION
исправлена работа с опциональными параметрами в клиентах к методам:
/V2/GenerateRevocationRequestXml
/GenerateInvoiceXml
/GenerateTitleXml
/GenerateRecipientTitleXml
/GenerateTorg12XmlForSeller
/GenerateTorg12XmlForBuyer
/GenerateAcceptanceCertificateXmlForSeller
/GenerateAcceptanceCertificateXmlForBuyer
/GenerateUniversalTransferDocumentXmlForSeller

Исправлена логика метода:
/V2/GetForwardedEntityContent

Исправлена сборка на windows