### PR TITLE
Генерация аннотации для устаревших моделей

### DIFF
--- a/proto/Docflow/BilateralDocflow.proto
+++ b/proto/Docflow/BilateralDocflow.proto
@@ -8,6 +8,7 @@ option java_outer_classname = "BilateralDocflowProtos";
 
 message BilateralDocflow
 {
+	option deprecated = true;
 	optional bool IsFinished = 1;
 
 	optional ReceiptDocflow ReceiptDocflow = 2;

--- a/proto/Docflow/Docflow.proto
+++ b/proto/Docflow/Docflow.proto
@@ -16,6 +16,7 @@ option java_outer_classname = "DocflowProtos";
 
 message Docflow
 {
+	option deprecated = true;
 	optional bool IsFinished = 1;
 
 	optional SignedAttachment DocumentAttachment = 2;
@@ -47,12 +48,14 @@ message Docflow
 
 message DocflowStatus
 {
+	option deprecated = true;
 	optional DocflowStatusModel PrimaryStatus = 1;
 	optional DocflowStatusModel SecondaryStatus = 2;
 }
 
 message DocflowStatusModel
 {
+	option deprecated = true;
 	optional DocflowStatusSeverity Severity = 1 [default = UnknownDocflowStatusSeverity];
 	optional string StatusText = 2;
 	optional string StatusHint = 3;

--- a/proto/Docflow/DocflowApi.proto
+++ b/proto/Docflow/DocflowApi.proto
@@ -26,6 +26,7 @@ message GetDocflowRequest
 
 message GetDocflowBatchResponse
 {
+	option deprecated = true;
 	repeated DocumentWithDocflow Documents = 1;
 }
 
@@ -49,6 +50,7 @@ message SearchDocflowsRequest
 
 message SearchDocflowsResponse
 {
+	option deprecated = true;
 	repeated DocumentWithDocflow Documents = 1;
 	optional bool HaveMoreDocuments = 2;
 }
@@ -63,12 +65,14 @@ message GetDocflowsByPacketIdRequest
 
 message FetchedDocument
 {
+	option deprecated = true;
 	required DocumentWithDocflow Document = 1;
 	required bytes IndexKey = 2;
 }
 
 message GetDocflowsByPacketIdResponse
 {
+	option deprecated = true;
 	repeated FetchedDocument Documents = 1;
 	optional bytes NextPageIndexKey = 2;
 }
@@ -90,6 +94,7 @@ message GetDocflowEventsRequest
 
 message GetDocflowEventsResponse
 {
+	option deprecated = true;
 	optional int32 TotalCount = 1;
 	repeated DocflowEvent Events = 2;
 	required TotalCountType TotalCountType = 3;
@@ -97,6 +102,7 @@ message GetDocflowEventsResponse
 
 message DocflowEvent
 {
+	option deprecated = true;
 	optional string EventId = 1;
 	optional Timestamp Timestamp = 2;
 	optional DocumentId DocumentId = 3;

--- a/proto/Docflow/DocumentInfo.proto
+++ b/proto/Docflow/DocumentInfo.proto
@@ -8,6 +8,7 @@ option java_outer_classname = "DocumentInfoProtos";
 
 message DocumentInfo
 {
+	option deprecated = true;
 	optional DocumentType DocumentType = 1 [default = UnknownDocumentType];
 	optional DocumentDirection DocumentDirection = 2 [default = UnknownDocumentDirection];
 	optional bool IsTest = 3;
@@ -30,12 +31,14 @@ message DocumentInfo
 
 message DocumentDateAndNumber
 {
+	option deprecated = true;
 	optional string DocumentDate = 1;
 	optional string DocumentNumber = 2;
 }
 
 message BasicDocumentInfo
 {
+	option deprecated = true;
 	optional string Total = 1;
 	optional bool NoVat = 2;
 	optional string Vat = 3;
@@ -45,6 +48,7 @@ message BasicDocumentInfo
 
 message InvoiceDocumentInfo
 {
+	option deprecated = true;
 	optional string Total = 1;
 	optional string Vat = 2;
 	optional int32 CurrencyCode = 3;
@@ -53,6 +57,7 @@ message InvoiceDocumentInfo
 
 message InvoiceCorrectionDocumentInfo
 {
+	option deprecated = true;
 	optional string TotalInc = 1;
 	optional string TotalDec = 2;
 	optional string VatInc = 3;
@@ -65,18 +70,21 @@ message InvoiceCorrectionDocumentInfo
 
 message PriceListDocumentInfo
 {
+	option deprecated = true;
 	optional string PriceListEffectiveDate = 1;
 	optional DocumentDateAndNumber ContractDocumentDateAndNumber = 2;
 }
 
 message ContractDocumentInfo
 {
+	option deprecated = true;
 	optional string ContractPrice = 1;
 	optional string ContractType = 2;
 }
 
 message SupplementaryAgreementDocumentInfo
 {
+	option deprecated = true;
 	optional string ContractType = 1;
 	required DocumentDateAndNumber ContractDocumentDateAndNumber = 2;
 	required DocumentDateAndNumber DocumentDateAndNumber = 3;
@@ -85,6 +93,7 @@ message SupplementaryAgreementDocumentInfo
 
 message UniversalTransferDocumentInfo
 {
+	option deprecated = true;
 	optional string Total = 1;
 	optional string Vat = 2;
 	optional int32 CurrencyCode = 3;
@@ -95,6 +104,7 @@ message UniversalTransferDocumentInfo
 
 message UniversalCorrectionDocumentInfo
 {
+	option deprecated = true;
 	optional string TotalInc = 1;
 	optional string TotalDec = 2;
 	optional string VatInc = 3;

--- a/proto/Docflow/DocumentWithDocflow.proto
+++ b/proto/Docflow/DocumentWithDocflow.proto
@@ -8,8 +8,11 @@ package Diadoc.Api.Proto.Docflow;
 
 option java_outer_classname = "DocumentWithDocflowProtos";
 
+option deprecated = true;
+
 message DocumentWithDocflow
 {
+	option deprecated = true;
 	optional DocumentId DocumentId = 1;
 	optional string LastEventId = 2;
 	optional Timestamp LastEventTimestamp = 3;

--- a/proto/Docflow/InvoiceDocflow.proto
+++ b/proto/Docflow/InvoiceDocflow.proto
@@ -8,6 +8,7 @@ option java_outer_classname = "InvoiceDocflowProtos";
 
 message InboundInvoiceDocflow
 {
+	option deprecated = true;
 	optional bool IsFinished = 1;
 
 	optional InboundInvoiceReceiptDocflow ReceiptDocflow = 2;
@@ -23,6 +24,7 @@ message InboundInvoiceDocflow
 
 message OutboundInvoiceDocflow
 {
+	option deprecated = true;
 	optional bool IsFinished = 1;
 
 	optional ReceiptDocflow ReceiptDocflow = 2;
@@ -40,6 +42,7 @@ message OutboundInvoiceDocflow
 
 message InvoiceConfirmationDocflow
 {
+	option deprecated = true;
 	optional bool IsFinished = 1;
 
 	optional SignedAttachment ConfirmationAttachment = 2;
@@ -49,6 +52,7 @@ message InvoiceConfirmationDocflow
 
 message InboundInvoiceReceiptDocflow
 {
+	option deprecated = true;
 	optional bool IsFinished = 1;
 
 	optional SignedAttachment ReceiptAttachment = 2;
@@ -58,6 +62,7 @@ message InboundInvoiceReceiptDocflow
 
 message InvoiceCorrectionRequestDocflow
 {
+	option deprecated = true;
 	optional bool IsFinished = 1;
 
 	optional SignedAttachment CorrectionRequestAttachment = 2;

--- a/proto/Docflow/ReceiptDocflow.proto
+++ b/proto/Docflow/ReceiptDocflow.proto
@@ -6,6 +6,8 @@ option java_outer_classname = "ReceiptDocflowProtos";
 
 message ReceiptDocflow
 {
+	option deprecated = true;
+
 	optional bool IsFinished = 1;
 
 	optional SignedAttachment ReceiptAttachment = 2;

--- a/proto/Docflow/RecipientSignatureDocflow.proto
+++ b/proto/Docflow/RecipientSignatureDocflow.proto
@@ -7,6 +7,8 @@ option java_outer_classname = "RecipientSignatureDocflowProtos";
 
 message RecipientSignatureDocflow
 {
+	option deprecated = true;
+
 	optional bool IsFinished = 1;
 
 	optional Signature RecipientSignature = 2;

--- a/proto/Docflow/RecipientSignatureRejectionDocflow.proto
+++ b/proto/Docflow/RecipientSignatureRejectionDocflow.proto
@@ -5,8 +5,12 @@ package Diadoc.Api.Proto.Docflow;
 
 option java_outer_classname = "RecipientSignatureRejectionDocflowProtos";
 
+option deprecated = true;
+
 message RecipientSignatureRejectionDocflow
 {
+	option deprecated = true;
+
 	optional bool IsFinished = 1;
 
 	optional SignedAttachment RecipientSignatureRejectionAttachment = 2;

--- a/proto/Docflow/RevocationDocflow.proto
+++ b/proto/Docflow/RevocationDocflow.proto
@@ -6,8 +6,12 @@ package Diadoc.Api.Proto.Docflow;
 
 option java_outer_classname = "RevocationDocflowProtos";
 
+option deprecated = true;
+
 message RevocationDocflow
 {
+	option deprecated = true;
+
 	optional bool IsFinished = 1;
 	
 	optional SignedAttachment RevocationRequestAttachment = 2;

--- a/proto/Docflow/UnilateralDocflow.proto
+++ b/proto/Docflow/UnilateralDocflow.proto
@@ -4,8 +4,12 @@ package Diadoc.Api.Proto.Docflow;
 
 option java_outer_classname = "UnilateralDocflowProtos";
 
+option deprecated = true;
+
 message UnilateralDocflow
 {
+	option deprecated = true;
+
 	optional bool IsFinished = 1;
 
 	optional ReceiptDocflow ReceiptDocflow = 2;

--- a/proto/Docflow/UniversalTransferDocumentDocflow.proto
+++ b/proto/Docflow/UniversalTransferDocumentDocflow.proto
@@ -9,8 +9,11 @@ package Diadoc.Api.Proto.Docflow;
 
 option java_outer_classname = "UniversalTransferDocumentDocflowProtos";
 
+option deprecated = true;
+
 message InboundUniversalTransferDocumentDocflow
 {
+  option deprecated = true;
   optional bool IsFinished = 1;
 
   optional InboundInvoiceReceiptDocflow ReceiptDocflow = 2;
@@ -37,6 +40,7 @@ message InboundUniversalTransferDocumentDocflow
 
 message OutboundUniversalTransferDocumentDocflow
 {
+  option deprecated = true;
   optional bool IsFinished = 1;
 
   optional ReceiptDocflow ReceiptDocflow = 2;

--- a/proto/Docflow/XmlBilateralDocflow.proto
+++ b/proto/Docflow/XmlBilateralDocflow.proto
@@ -7,8 +7,12 @@ package Diadoc.Api.Proto.Docflow;
 
 option java_outer_classname = "XmlBilateralDocflowProtos";
 
+option deprecated = true;
+
 message XmlBilateralDocflow
 {
+	option deprecated = true;
+
 	optional bool IsFinished = 1;
 
 	optional ReceiptDocflow ReceiptDocflow = 2;
@@ -26,6 +30,7 @@ message XmlBilateralDocflow
 
 message BuyerTitleDocflow
 {
+	option deprecated = true;
 	optional bool IsFinished = 1;
 
 	optional SignedAttachment BuyerTitleAttachment = 2;

--- a/proto/Documents/BilateralDocument.proto
+++ b/proto/Documents/BilateralDocument.proto
@@ -43,6 +43,7 @@ message SupplementaryAgreementMetadata {
 }
 
 message BilateralDocumentMetadata {
+	option deprecated = true;
 	optional BilateralDocumentStatus DocumentStatus = 1 [default = UnknownBilateralDocumentStatus];
 	optional ReceiptStatus ReceiptStatus = 2 [default = UnknownReceiptStatus];
 }

--- a/proto/Documents/NonformalizedDocument.proto
+++ b/proto/Documents/NonformalizedDocument.proto
@@ -5,6 +5,7 @@ package Diadoc.Api.Proto.Documents.NonformalizedDocument;
 option java_outer_classname = "NonformalizedDocumentProtos";
 
 message NonformalizedDocumentMetadata {
+	option deprecated = true;
 	optional NonformalizedDocumentStatus DocumentStatus = 1 [default = UnknownNonformalizedDocumentStatus];
 	optional ReceiptStatus ReceiptStatus = 2 [default = UnknownReceiptStatus];
 }

--- a/proto/Events/DiadocMessage-PostApi.proto
+++ b/proto/Events/DiadocMessage-PostApi.proto
@@ -58,6 +58,7 @@ message MessageToPost {
 }
 
 message EncryptedXmlDocumentAttachment {
+	option deprecated = true;
 	required SignedContent SignedContent = 1;
 	optional string Comment = 3;
 	repeated DocumentId InitialDocumentIds = 4;
@@ -69,6 +70,7 @@ message EncryptedXmlDocumentAttachment {
 }
 
 message EncryptedInvoiceAttachment {
+	option deprecated = true;
 	required SignedContent SignedContent = 1;
 	optional string Comment = 3;
 	repeated DocumentId InitialDocumentIds = 4;
@@ -81,6 +83,7 @@ message EncryptedInvoiceAttachment {
 }
 
 message EncryptedDocumentMetadata {
+	option deprecated = true;
 	required string FileId = 1;
 	required string BuyerFnsParticipantId = 2;
 	required string SenderFnsParticipantId = 3;
@@ -104,6 +107,7 @@ message EncryptedInvoiceCorrectionMetadata {
 }
 
 message XmlDocumentAttachment {
+	option deprecated = true;
 	required SignedContent SignedContent = 1;
 	optional string Comment = 3;
 	repeated DocumentId InitialDocumentIds = 4;
@@ -114,6 +118,7 @@ message XmlDocumentAttachment {
 }
 
 message NonformalizedAttachment {
+	option deprecated = true;
 	required SignedContent SignedContent = 1;
 	required string FileName = 2;
 	optional string Comment = 3;
@@ -128,6 +133,7 @@ message NonformalizedAttachment {
 }
 
 message BasicDocumentAttachment {
+	option deprecated = true;
 	required SignedContent SignedContent = 1;
 	required string FileName = 2;
 	optional string Comment = 3;
@@ -144,6 +150,7 @@ message BasicDocumentAttachment {
 }
 
 message Torg13Attachment {
+	option deprecated = true;
 	required SignedContent SignedContent = 1;
 	required string FileName = 2;
 	optional string Comment = 3;
@@ -160,6 +167,7 @@ message Torg13Attachment {
 }
 
 message AcceptanceCertificateAttachment {
+	option deprecated = true;
 	required SignedContent SignedContent = 1;
 	required string FileName = 2;
 	optional string Comment = 3;
@@ -177,6 +185,7 @@ message AcceptanceCertificateAttachment {
 }
 
 message TrustConnectionRequestAttachment {
+	option deprecated = true;
 	required SignedContent SignedContent = 1;
 	required string FileName = 2;
 	optional string Comment = 3;
@@ -191,6 +200,7 @@ message StructuredDataAttachment {
 }
 
 message PriceListAttachment {
+	option deprecated = true;
 	required SignedContent SignedContent = 1;
 	required string FileName = 2;
 	optional string Comment = 3;
@@ -207,6 +217,7 @@ message PriceListAttachment {
 }
 
 message ReconciliationActAttachment {
+	option deprecated = true;
 	required SignedContent SignedContent = 1;
 	required string FileName = 2;
 	optional string Comment = 3;
@@ -221,6 +232,7 @@ message ReconciliationActAttachment {
 }
 
 message ContractAttachment {
+	option deprecated = true;
 	required SignedContent SignedContent = 1;
 	required string FileName = 2;
 	optional string Comment = 3;
@@ -236,6 +248,7 @@ message ContractAttachment {
 }
 
 message SupplementaryAgreementAttachment {
+	option deprecated = true;
 	required SignedContent SignedContent = 1;
 	required string FileName = 2;
 	optional string Comment = 3;
@@ -253,6 +266,7 @@ message SupplementaryAgreementAttachment {
 }
 
 message ServiceDetailsAttachment {
+	option deprecated = true;
 	required SignedContent SignedContent = 1;
 	required string FileName = 2;
 	optional string Comment = 3;

--- a/proto/ExternalServiceAuthInfo.proto
+++ b/proto/ExternalServiceAuthInfo.proto
@@ -2,7 +2,10 @@ package Diadoc.Api.Proto;
 
 option java_outer_classname = "ExternalServiceAuthInfoProtos";
 
+option deprecated = true;
+
 message ExternalServiceAuthInfo {
+	option deprecated = true;
 	optional string ServiceUserId = 1;
 	optional string Thumbprint = 2;
 }

--- a/proto/Invoicing/ExtendedOrganizationInfo.proto
+++ b/proto/Invoicing/ExtendedOrganizationInfo.proto
@@ -5,6 +5,7 @@ package Diadoc.Api.Proto.Invoicing.Organizations;
 option java_outer_classname = "ExtendedOrganizationInfoProtos";
 
 message ExtendedOrganizationInfo {
+  option deprecated = true;
   optional string BoxId = 1;       // идентификатор ящика в Диадоке
   optional string OrgName = 2;     // название //НаимОрг
   optional string Inn = 3;         // ИНН //ИНН ФЛ-ИНН

--- a/proto/Invoicing/Official.proto
+++ b/proto/Invoicing/Official.proto
@@ -2,8 +2,11 @@ package Diadoc.Api.Proto.Invoicing;
 
 option java_outer_classname = "OfficialProtos";
 
+option deprecated = true;
+
 // Должностное лицо
 message Official {
+	option deprecated = true;
 	required string Surname = 1;
 	required string FirstName = 2;
 	optional string Patronymic = 3;
@@ -11,6 +14,7 @@ message Official {
 }
 
 message Attorney {
+	option deprecated = true;
 	optional string Date = 1;						// дата выдачи доверенности
 	optional string Number = 2;						// номер доверенности
 	optional string IssuerOrganizationName = 3;		// организация, представитель которой выдал доверенность

--- a/proto/Invoicing/OrganizationInfo.proto
+++ b/proto/Invoicing/OrganizationInfo.proto
@@ -4,7 +4,10 @@ package Diadoc.Api.Proto.Invoicing;
 
 option java_outer_classname = "OrganizationInfoProtos";
 
+option deprecated = true;
+
 message DocflowParticipant {
+	option deprecated = true;
 	optional string BoxId = 1;								// идентификатор ящика в Диадоке
 	optional string Inn = 2;								// ИНН организации-участника обмена
 	optional string Kpp = 3;								// КПП организации-участника обмена
@@ -12,11 +15,13 @@ message DocflowParticipant {
 }
 
 message DiadocOrganizationInfo {
+	option deprecated = true;
 	optional string BoxId = 1;								// идентификатор ящика в Диадоке
 	optional OrganizationInfo OrgInfo = 2;					// реквизиты организации
 }
 
 message OrganizationInfo {
+	option deprecated = true;
 	required string Name = 1;								// название
 	optional string Inn = 2;								// ИНН
 	optional string Kpp = 3;								// КПП

--- a/proto/User.proto
+++ b/proto/User.proto
@@ -5,6 +5,7 @@ package Diadoc.Api.Proto;
 option java_outer_classname = "UserProtos";
 
 message User {
+	option deprecated = true;
 	optional string Id = 1;
 	optional string LastName = 2;
 	optional string FirstName = 3;

--- a/proto/Users/UserToUpdate.proto
+++ b/proto/Users/UserToUpdate.proto
@@ -6,6 +6,7 @@ option java_outer_classname = "UserToUpdateProtos";
 
 message UserToUpdate
 {
+	option deprecated = true;
 	optional UserLoginPatch Login = 1;
 	optional UserFullNamePatch FullName = 2;
 }

--- a/src/main/java/Diadoc/Api/Proto/Docflow/BilateralDocflowProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Docflow/BilateralDocflowProtos.java
@@ -25,7 +25,7 @@ public final class BilateralDocflowProtos {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
-  public interface BilateralDocflowOrBuilder extends
+  @java.lang.Deprecated public interface BilateralDocflowOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.BilateralDocflow)
       com.google.protobuf.MessageOrBuilder {
 
@@ -165,7 +165,7 @@ public final class BilateralDocflowProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.BilateralDocflow}
    */
-  public static final class BilateralDocflow extends
+  @java.lang.Deprecated public static final class BilateralDocflow extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.BilateralDocflow)
       BilateralDocflowOrBuilder {
@@ -1846,7 +1846,7 @@ public final class BilateralDocflowProtos {
       ".Api.Proto.Docflow\032\034Docflow/ReceiptDocfl" +
       "ow.proto\032\'Docflow/RecipientSignatureDocf" +
       "low.proto\0320Docflow/RecipientSignatureRej" +
-      "ectionDocflow.proto\"\260\004\n\020BilateralDocflow" +
+      "ectionDocflow.proto\"\264\004\n\020BilateralDocflow" +
       "\022\022\n\nIsFinished\030\001 \001(\010\022@\n\016ReceiptDocflow\030\002" +
       " \001(\0132(.Diadoc.Api.Proto.Docflow.ReceiptD" +
       "ocflow\022V\n\031RecipientSignatureDocflow\030\003 \001(" +
@@ -1860,8 +1860,8 @@ public final class BilateralDocflowProtos {
       "jectedByRecipient\030\010 \001(\010\022\036\n\026CanDocumentBe" +
       "Receipted\030\t \001(\010\022#\n\033CanDocumentBeSignedBy" +
       "Sender\030\n \001(\010\0220\n(CanDocumentBeSignedOrRej" +
-      "ectedByRecipient\030\013 \001(\010B\030B\026BilateralDocfl" +
-      "owProtos"
+      "ectedByRecipient\030\013 \001(\010:\002\030\001B\030B\026BilateralD" +
+      "ocflowProtos"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/src/main/java/Diadoc/Api/Proto/Docflow/DocflowApiProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Docflow/DocflowApiProtos.java
@@ -1769,7 +1769,7 @@ public final class DocflowApiProtos {
 
   }
 
-  public interface GetDocflowBatchResponseOrBuilder extends
+  @java.lang.Deprecated public interface GetDocflowBatchResponseOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.GetDocflowBatchResponse)
       com.google.protobuf.MessageOrBuilder {
 
@@ -1800,7 +1800,7 @@ public final class DocflowApiProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.GetDocflowBatchResponse}
    */
-  public static final class GetDocflowBatchResponse extends
+  @java.lang.Deprecated public static final class GetDocflowBatchResponse extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.GetDocflowBatchResponse)
       GetDocflowBatchResponseOrBuilder {
@@ -3475,7 +3475,7 @@ public final class DocflowApiProtos {
 
   }
 
-  public interface SearchDocflowsResponseOrBuilder extends
+  @java.lang.Deprecated public interface SearchDocflowsResponseOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.SearchDocflowsResponse)
       com.google.protobuf.MessageOrBuilder {
 
@@ -3517,7 +3517,7 @@ public final class DocflowApiProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.SearchDocflowsResponse}
    */
-  public static final class SearchDocflowsResponse extends
+  @java.lang.Deprecated public static final class SearchDocflowsResponse extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.SearchDocflowsResponse)
       SearchDocflowsResponseOrBuilder {
@@ -5178,7 +5178,7 @@ public final class DocflowApiProtos {
 
   }
 
-  public interface FetchedDocumentOrBuilder extends
+  @java.lang.Deprecated public interface FetchedDocumentOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.FetchedDocument)
       com.google.protobuf.MessageOrBuilder {
 
@@ -5211,7 +5211,7 @@ public final class DocflowApiProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.FetchedDocument}
    */
-  public static final class FetchedDocument extends
+  @java.lang.Deprecated public static final class FetchedDocument extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.FetchedDocument)
       FetchedDocumentOrBuilder {
@@ -5869,7 +5869,7 @@ public final class DocflowApiProtos {
 
   }
 
-  public interface GetDocflowsByPacketIdResponseOrBuilder extends
+  @java.lang.Deprecated public interface GetDocflowsByPacketIdResponseOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.GetDocflowsByPacketIdResponse)
       com.google.protobuf.MessageOrBuilder {
 
@@ -5911,7 +5911,7 @@ public final class DocflowApiProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.GetDocflowsByPacketIdResponse}
    */
-  public static final class GetDocflowsByPacketIdResponse extends
+  @java.lang.Deprecated public static final class GetDocflowsByPacketIdResponse extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.GetDocflowsByPacketIdResponse)
       GetDocflowsByPacketIdResponseOrBuilder {
@@ -8800,7 +8800,7 @@ public final class DocflowApiProtos {
 
   }
 
-  public interface GetDocflowEventsResponseOrBuilder extends
+  @java.lang.Deprecated public interface GetDocflowEventsResponseOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.GetDocflowEventsResponse)
       com.google.protobuf.MessageOrBuilder {
 
@@ -8853,7 +8853,7 @@ public final class DocflowApiProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.GetDocflowEventsResponse}
    */
-  public static final class GetDocflowEventsResponse extends
+  @java.lang.Deprecated public static final class GetDocflowEventsResponse extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.GetDocflowEventsResponse)
       GetDocflowEventsResponseOrBuilder {
@@ -9767,7 +9767,7 @@ public final class DocflowApiProtos {
 
   }
 
-  public interface DocflowEventOrBuilder extends
+  @java.lang.Deprecated public interface DocflowEventOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.DocflowEvent)
       com.google.protobuf.MessageOrBuilder {
 
@@ -9879,7 +9879,7 @@ public final class DocflowApiProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.DocflowEvent}
    */
-  public static final class DocflowEvent extends
+  @java.lang.Deprecated public static final class DocflowEvent extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.DocflowEvent)
       DocflowEventOrBuilder {
@@ -11508,51 +11508,52 @@ public final class DocflowApiProtos {
       "etDocflowRequest\"~\n\021GetDocflowRequest\0220\n" +
       "\nDocumentId\030\001 \002(\0132\034.Diadoc.Api.Proto.Doc" +
       "umentId\022\023\n\013LastEventId\030\002 \001(\t\022\"\n\023InjectEn" +
-      "tityContent\030\003 \001(\010:\005false\"[\n\027GetDocflowBa" +
+      "tityContent\030\003 \001(\010:\005false\"_\n\027GetDocflowBa" +
       "tchResponse\022@\n\tDocuments\030\001 \003(\0132-.Diadoc." +
-      "Api.Proto.Docflow.DocumentWithDocflow\"\276\001" +
-      "\n\025SearchDocflowsRequest\022\023\n\013QueryString\030\001" +
-      " \002(\t\022\022\n\005Count\030\002 \001(\005:\003100\022\022\n\nFirstIndex\030\003" +
-      " \001(\005\022D\n\005Scope\030\004 \001(\0162%.Diadoc.Api.Proto.D" +
-      "ocflow.SearchScope:\016SearchScopeAny\022\"\n\023In" +
-      "jectEntityContent\030\005 \001(\010:\005false\"u\n\026Search" +
-      "DocflowsResponse\022@\n\tDocuments\030\001 \003(\0132-.Di" +
+      "Api.Proto.Docflow.DocumentWithDocflow:\002\030" +
+      "\001\"\276\001\n\025SearchDocflowsRequest\022\023\n\013QueryStri" +
+      "ng\030\001 \002(\t\022\022\n\005Count\030\002 \001(\005:\003100\022\022\n\nFirstInd" +
+      "ex\030\003 \001(\005\022D\n\005Scope\030\004 \001(\0162%.Diadoc.Api.Pro" +
+      "to.Docflow.SearchScope:\016SearchScopeAny\022\"" +
+      "\n\023InjectEntityContent\030\005 \001(\010:\005false\"y\n\026Se" +
+      "archDocflowsResponse\022@\n\tDocuments\030\001 \003(\0132" +
+      "-.Diadoc.Api.Proto.Docflow.DocumentWithD" +
+      "ocflow\022\031\n\021HaveMoreDocuments\030\002 \001(\010:\002\030\001\"\177\n" +
+      "\034GetDocflowsByPacketIdRequest\022\020\n\010PacketI" +
+      "d\030\001 \002(\t\022\022\n\005Count\030\002 \001(\005:\003100\022\"\n\023InjectEnt" +
+      "ityContent\030\003 \001(\010:\005false\022\025\n\rAfterIndexKey" +
+      "\030\004 \001(\014\"h\n\017FetchedDocument\022?\n\010Document\030\001 " +
+      "\002(\0132-.Diadoc.Api.Proto.Docflow.DocumentW" +
+      "ithDocflow\022\020\n\010IndexKey\030\002 \002(\014:\002\030\001\"{\n\035GetD" +
+      "ocflowsByPacketIdResponse\022<\n\tDocuments\030\001" +
+      " \003(\0132).Diadoc.Api.Proto.Docflow.FetchedD" +
+      "ocument\022\030\n\020NextPageIndexKey\030\002 \001(\014:\002\030\001\"\345\002" +
+      "\n\027GetDocflowEventsRequest\0221\n\006Filter\030\001 \002(" +
+      "\0132!.Diadoc.Api.Proto.TimeBasedFilter\022\025\n\r" +
+      "AfterIndexKey\030\002 \001(\014\022 \n\021PopulateDocuments" +
+      "\030\003 \001(\010:\005false\022\"\n\023InjectEntityContent\030\004 \001" +
+      "(\010:\005false\022-\n\036PopulatePreviousDocumentSta" +
+      "tes\030\005 \001(\010:\005false\022\024\n\014MessageTypes\030\006 \003(\t\022\032" +
+      "\n\022DocumentDirections\030\007 \003(\t\022\024\n\014Department" +
+      "Id\030\010 \001(\t\022\024\n\014TypeNamedIds\030\t \003(\t\022\031\n\021Counte" +
+      "ragentBoxId\030\n \001(\t\022\022\n\005Limit\030\013 \001(\005:\003100\"\244\001" +
+      "\n\030GetDocflowEventsResponse\022\022\n\nTotalCount" +
+      "\030\001 \001(\005\0226\n\006Events\030\002 \003(\0132&.Diadoc.Api.Prot" +
+      "o.Docflow.DocflowEvent\0228\n\016TotalCountType" +
+      "\030\003 \002(\0162 .Diadoc.Api.Proto.TotalCountType" +
+      ":\002\030\001\"\277\002\n\014DocflowEvent\022\017\n\007EventId\030\001 \001(\t\022." +
+      "\n\tTimestamp\030\002 \001(\0132\033.Diadoc.Api.Proto.Tim" +
+      "estamp\0220\n\nDocumentId\030\003 \001(\0132\034.Diadoc.Api." +
+      "Proto.DocumentId\022\020\n\010IndexKey\030\004 \001(\014\022?\n\010Do" +
+      "cument\030\005 \001(\0132-.Diadoc.Api.Proto.Docflow." +
+      "DocumentWithDocflow\022\027\n\017PreviousEventId\030\006" +
+      " \001(\t\022L\n\025PreviousDocumentState\030\007 \001(\0132-.Di" +
       "adoc.Api.Proto.Docflow.DocumentWithDocfl" +
-      "ow\022\031\n\021HaveMoreDocuments\030\002 \001(\010\"\177\n\034GetDocf" +
-      "lowsByPacketIdRequest\022\020\n\010PacketId\030\001 \002(\t\022" +
-      "\022\n\005Count\030\002 \001(\005:\003100\022\"\n\023InjectEntityConte" +
-      "nt\030\003 \001(\010:\005false\022\025\n\rAfterIndexKey\030\004 \001(\014\"d" +
-      "\n\017FetchedDocument\022?\n\010Document\030\001 \002(\0132-.Di" +
-      "adoc.Api.Proto.Docflow.DocumentWithDocfl" +
-      "ow\022\020\n\010IndexKey\030\002 \002(\014\"w\n\035GetDocflowsByPac" +
-      "ketIdResponse\022<\n\tDocuments\030\001 \003(\0132).Diado" +
-      "c.Api.Proto.Docflow.FetchedDocument\022\030\n\020N" +
-      "extPageIndexKey\030\002 \001(\014\"\345\002\n\027GetDocflowEven" +
-      "tsRequest\0221\n\006Filter\030\001 \002(\0132!.Diadoc.Api.P" +
-      "roto.TimeBasedFilter\022\025\n\rAfterIndexKey\030\002 " +
-      "\001(\014\022 \n\021PopulateDocuments\030\003 \001(\010:\005false\022\"\n" +
-      "\023InjectEntityContent\030\004 \001(\010:\005false\022-\n\036Pop" +
-      "ulatePreviousDocumentStates\030\005 \001(\010:\005false" +
-      "\022\024\n\014MessageTypes\030\006 \003(\t\022\032\n\022DocumentDirect" +
-      "ions\030\007 \003(\t\022\024\n\014DepartmentId\030\010 \001(\t\022\024\n\014Type" +
-      "NamedIds\030\t \003(\t\022\031\n\021CounteragentBoxId\030\n \001(" +
-      "\t\022\022\n\005Limit\030\013 \001(\005:\003100\"\240\001\n\030GetDocflowEven" +
-      "tsResponse\022\022\n\nTotalCount\030\001 \001(\005\0226\n\006Events" +
-      "\030\002 \003(\0132&.Diadoc.Api.Proto.Docflow.Docflo" +
-      "wEvent\0228\n\016TotalCountType\030\003 \002(\0162 .Diadoc." +
-      "Api.Proto.TotalCountType\"\273\002\n\014DocflowEven" +
-      "t\022\017\n\007EventId\030\001 \001(\t\022.\n\tTimestamp\030\002 \001(\0132\033." +
-      "Diadoc.Api.Proto.Timestamp\0220\n\nDocumentId" +
-      "\030\003 \001(\0132\034.Diadoc.Api.Proto.DocumentId\022\020\n\010" +
-      "IndexKey\030\004 \001(\014\022?\n\010Document\030\005 \001(\0132-.Diado" +
-      "c.Api.Proto.Docflow.DocumentWithDocflow\022" +
-      "\027\n\017PreviousEventId\030\006 \001(\t\022L\n\025PreviousDocu" +
-      "mentState\030\007 \001(\0132-.Diadoc.Api.Proto.Docfl" +
-      "ow.DocumentWithDocflow*\204\001\n\013SearchScope\022\022" +
-      "\n\016SearchScopeAny\020\000\022\027\n\023SearchScopeIncomin" +
-      "g\020\001\022\027\n\023SearchScopeOutgoing\020\002\022\026\n\022SearchSc" +
-      "opeDeleted\020\003\022\027\n\023SearchScopeInternal\020\004B\022B" +
-      "\020DocflowApiProtos"
+      "ow:\002\030\001*\204\001\n\013SearchScope\022\022\n\016SearchScopeAny" +
+      "\020\000\022\027\n\023SearchScopeIncoming\020\001\022\027\n\023SearchSco" +
+      "peOutgoing\020\002\022\026\n\022SearchScopeDeleted\020\003\022\027\n\023" +
+      "SearchScopeInternal\020\004B\022B\020DocflowApiProto" +
+      "s"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/src/main/java/Diadoc/Api/Proto/Docflow/DocflowProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Docflow/DocflowProtos.java
@@ -165,7 +165,7 @@ public final class DocflowProtos {
     // @@protoc_insertion_point(enum_scope:Diadoc.Api.Proto.Docflow.DocflowStatusSeverity)
   }
 
-  public interface DocflowOrBuilder extends
+  @java.lang.Deprecated public interface DocflowOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.Docflow)
       com.google.protobuf.MessageOrBuilder {
 
@@ -557,7 +557,7 @@ public final class DocflowProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.Docflow}
    */
-  public static final class Docflow extends
+  @java.lang.Deprecated public static final class Docflow extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.Docflow)
       DocflowOrBuilder {
@@ -4931,7 +4931,7 @@ public final class DocflowProtos {
 
   }
 
-  public interface DocflowStatusOrBuilder extends
+  @java.lang.Deprecated public interface DocflowStatusOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.DocflowStatus)
       com.google.protobuf.MessageOrBuilder {
 
@@ -4968,7 +4968,7 @@ public final class DocflowProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.DocflowStatus}
    */
-  public static final class DocflowStatus extends
+  @java.lang.Deprecated public static final class DocflowStatus extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.DocflowStatus)
       DocflowStatusOrBuilder {
@@ -5701,7 +5701,7 @@ public final class DocflowProtos {
 
   }
 
-  public interface DocflowStatusModelOrBuilder extends
+  @java.lang.Deprecated public interface DocflowStatusModelOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.DocflowStatusModel)
       com.google.protobuf.MessageOrBuilder {
 
@@ -5753,7 +5753,7 @@ public final class DocflowProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.DocflowStatusModel}
    */
-  public static final class DocflowStatusModel extends
+  @java.lang.Deprecated public static final class DocflowStatusModel extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.DocflowStatusModel)
       DocflowStatusModelOrBuilder {
@@ -6560,7 +6560,7 @@ public final class DocflowProtos {
       "roto\032\037Docflow/RevocationDocflow.proto\032\037D" +
       "ocflow/ResolutionDocflow.proto\032.Docflow/" +
       "UniversalTransferDocumentDocflow.proto\032!" +
-      "Docflow/RoamingNotification.proto\"\376\t\n\007Do" +
+      "Docflow/RoamingNotification.proto\"\202\n\n\007Do" +
       "cflow\022\022\n\nIsFinished\030\001 \001(\010\022F\n\022DocumentAtt" +
       "achment\030\002 \001(\0132*.Diadoc.Api.Proto.Docflow" +
       ".SignedAttachment\022\024\n\014DepartmentId\030\003 \001(\t\022" +
@@ -6592,18 +6592,19 @@ public final class DocflowProtos {
       "flow\030\023 \001(\0132B.Diadoc.Api.Proto.Docflow.Ou" +
       "tboundUniversalTransferDocumentDocflow\022J" +
       "\n\023RoamingNotification\030\024 \001(\0132-.Diadoc.Api" +
-      ".Proto.Docflow.RoamingNotification\"\233\001\n\rD" +
-      "ocflowStatus\022C\n\rPrimaryStatus\030\001 \001(\0132,.Di" +
-      "adoc.Api.Proto.Docflow.DocflowStatusMode" +
-      "l\022E\n\017SecondaryStatus\030\002 \001(\0132,.Diadoc.Api." +
-      "Proto.Docflow.DocflowStatusModel\"\235\001\n\022Doc" +
-      "flowStatusModel\022_\n\010Severity\030\001 \001(\0162/.Diad" +
-      "oc.Api.Proto.Docflow.DocflowStatusSeveri" +
-      "ty:\034UnknownDocflowStatusSeverity\022\022\n\nStat" +
-      "usText\030\002 \001(\t\022\022\n\nStatusHint\030\003 \001(\t*h\n\025Docf" +
-      "lowStatusSeverity\022 \n\034UnknownDocflowStatu" +
-      "sSeverity\020\000\022\010\n\004Info\020\001\022\013\n\007Success\020\002\022\013\n\007Wa" +
-      "rning\020\003\022\t\n\005Error\020\004B\017B\rDocflowProtos"
+      ".Proto.Docflow.RoamingNotification:\002\030\001\"\237" +
+      "\001\n\rDocflowStatus\022C\n\rPrimaryStatus\030\001 \001(\0132" +
+      ",.Diadoc.Api.Proto.Docflow.DocflowStatus" +
+      "Model\022E\n\017SecondaryStatus\030\002 \001(\0132,.Diadoc." +
+      "Api.Proto.Docflow.DocflowStatusModel:\002\030\001" +
+      "\"\241\001\n\022DocflowStatusModel\022_\n\010Severity\030\001 \001(" +
+      "\0162/.Diadoc.Api.Proto.Docflow.DocflowStat" +
+      "usSeverity:\034UnknownDocflowStatusSeverity" +
+      "\022\022\n\nStatusText\030\002 \001(\t\022\022\n\nStatusHint\030\003 \001(\t" +
+      ":\002\030\001*h\n\025DocflowStatusSeverity\022 \n\034Unknown" +
+      "DocflowStatusSeverity\020\000\022\010\n\004Info\020\001\022\013\n\007Suc" +
+      "cess\020\002\022\013\n\007Warning\020\003\022\t\n\005Error\020\004B\017B\rDocflo" +
+      "wProtos"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/src/main/java/Diadoc/Api/Proto/Docflow/DocumentInfoProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Docflow/DocumentInfoProtos.java
@@ -25,7 +25,7 @@ public final class DocumentInfoProtos {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
-  public interface DocumentInfoOrBuilder extends
+  @java.lang.Deprecated public interface DocumentInfoOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.DocumentInfo)
       com.google.protobuf.MessageOrBuilder {
 
@@ -362,7 +362,7 @@ public final class DocumentInfoProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.DocumentInfo}
    */
-  public static final class DocumentInfo extends
+  @java.lang.Deprecated public static final class DocumentInfo extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.DocumentInfo)
       DocumentInfoOrBuilder {
@@ -3911,7 +3911,7 @@ public final class DocumentInfoProtos {
 
   }
 
-  public interface DocumentDateAndNumberOrBuilder extends
+  @java.lang.Deprecated public interface DocumentDateAndNumberOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.DocumentDateAndNumber)
       com.google.protobuf.MessageOrBuilder {
 
@@ -3952,7 +3952,7 @@ public final class DocumentInfoProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.DocumentDateAndNumber}
    */
-  public static final class DocumentDateAndNumber extends
+  @java.lang.Deprecated public static final class DocumentDateAndNumber extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.DocumentDateAndNumber)
       DocumentDateAndNumberOrBuilder {
@@ -4630,7 +4630,7 @@ public final class DocumentInfoProtos {
 
   }
 
-  public interface BasicDocumentInfoOrBuilder extends
+  @java.lang.Deprecated public interface BasicDocumentInfoOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.BasicDocumentInfo)
       com.google.protobuf.MessageOrBuilder {
 
@@ -4714,7 +4714,7 @@ public final class DocumentInfoProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.BasicDocumentInfo}
    */
-  public static final class BasicDocumentInfo extends
+  @java.lang.Deprecated public static final class BasicDocumentInfo extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.BasicDocumentInfo)
       BasicDocumentInfoOrBuilder {
@@ -5831,7 +5831,7 @@ public final class DocumentInfoProtos {
 
   }
 
-  public interface InvoiceDocumentInfoOrBuilder extends
+  @java.lang.Deprecated public interface InvoiceDocumentInfoOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.InvoiceDocumentInfo)
       com.google.protobuf.MessageOrBuilder {
 
@@ -5910,7 +5910,7 @@ public final class DocumentInfoProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.InvoiceDocumentInfo}
    */
-  public static final class InvoiceDocumentInfo extends
+  @java.lang.Deprecated public static final class InvoiceDocumentInfo extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.InvoiceDocumentInfo)
       InvoiceDocumentInfoOrBuilder {
@@ -6914,7 +6914,7 @@ public final class DocumentInfoProtos {
 
   }
 
-  public interface InvoiceCorrectionDocumentInfoOrBuilder extends
+  @java.lang.Deprecated public interface InvoiceCorrectionDocumentInfoOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.InvoiceCorrectionDocumentInfo)
       com.google.protobuf.MessageOrBuilder {
 
@@ -7057,7 +7057,7 @@ public final class DocumentInfoProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.InvoiceCorrectionDocumentInfo}
    */
-  public static final class InvoiceCorrectionDocumentInfo extends
+  @java.lang.Deprecated public static final class InvoiceCorrectionDocumentInfo extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.InvoiceCorrectionDocumentInfo)
       InvoiceCorrectionDocumentInfoOrBuilder {
@@ -8751,7 +8751,7 @@ public final class DocumentInfoProtos {
 
   }
 
-  public interface PriceListDocumentInfoOrBuilder extends
+  @java.lang.Deprecated public interface PriceListDocumentInfoOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.PriceListDocumentInfo)
       com.google.protobuf.MessageOrBuilder {
 
@@ -8790,7 +8790,7 @@ public final class DocumentInfoProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.PriceListDocumentInfo}
    */
-  public static final class PriceListDocumentInfo extends
+  @java.lang.Deprecated public static final class PriceListDocumentInfo extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.PriceListDocumentInfo)
       PriceListDocumentInfoOrBuilder {
@@ -9498,7 +9498,7 @@ public final class DocumentInfoProtos {
 
   }
 
-  public interface ContractDocumentInfoOrBuilder extends
+  @java.lang.Deprecated public interface ContractDocumentInfoOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.ContractDocumentInfo)
       com.google.protobuf.MessageOrBuilder {
 
@@ -9539,7 +9539,7 @@ public final class DocumentInfoProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.ContractDocumentInfo}
    */
-  public static final class ContractDocumentInfo extends
+  @java.lang.Deprecated public static final class ContractDocumentInfo extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.ContractDocumentInfo)
       ContractDocumentInfoOrBuilder {
@@ -10217,7 +10217,7 @@ public final class DocumentInfoProtos {
 
   }
 
-  public interface SupplementaryAgreementDocumentInfoOrBuilder extends
+  @java.lang.Deprecated public interface SupplementaryAgreementDocumentInfoOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.SupplementaryAgreementDocumentInfo)
       com.google.protobuf.MessageOrBuilder {
 
@@ -10288,7 +10288,7 @@ public final class DocumentInfoProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.SupplementaryAgreementDocumentInfo}
    */
-  public static final class SupplementaryAgreementDocumentInfo extends
+  @java.lang.Deprecated public static final class SupplementaryAgreementDocumentInfo extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.SupplementaryAgreementDocumentInfo)
       SupplementaryAgreementDocumentInfoOrBuilder {
@@ -11355,7 +11355,7 @@ public final class DocumentInfoProtos {
 
   }
 
-  public interface UniversalTransferDocumentInfoOrBuilder extends
+  @java.lang.Deprecated public interface UniversalTransferDocumentInfoOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.UniversalTransferDocumentInfo)
       com.google.protobuf.MessageOrBuilder {
 
@@ -11462,7 +11462,7 @@ public final class DocumentInfoProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.UniversalTransferDocumentInfo}
    */
-  public static final class UniversalTransferDocumentInfo extends
+  @java.lang.Deprecated public static final class UniversalTransferDocumentInfo extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.UniversalTransferDocumentInfo)
       UniversalTransferDocumentInfoOrBuilder {
@@ -12729,7 +12729,7 @@ public final class DocumentInfoProtos {
 
   }
 
-  public interface UniversalCorrectionDocumentInfoOrBuilder extends
+  @java.lang.Deprecated public interface UniversalCorrectionDocumentInfoOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.UniversalCorrectionDocumentInfo)
       com.google.protobuf.MessageOrBuilder {
 
@@ -12900,7 +12900,7 @@ public final class DocumentInfoProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.UniversalCorrectionDocumentInfo}
    */
-  public static final class UniversalCorrectionDocumentInfo extends
+  @java.lang.Deprecated public static final class UniversalCorrectionDocumentInfo extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.UniversalCorrectionDocumentInfo)
       UniversalCorrectionDocumentInfoOrBuilder {
@@ -14919,7 +14919,7 @@ public final class DocumentInfoProtos {
       "\n\032Docflow/DocumentInfo.proto\022\030Diadoc.Api" +
       ".Proto.Docflow\032\022DocumentType.proto\032\027Docu" +
       "mentDirection.proto\032-Invoicing/Universal" +
-      "TransferDocumentInfo.proto\"\276\010\n\014DocumentI" +
+      "TransferDocumentInfo.proto\"\302\010\n\014DocumentI" +
       "nfo\022I\n\014DocumentType\030\001 \001(\0162\036.Diadoc.Api.P" +
       "roto.DocumentType:\023UnknownDocumentType\022X" +
       "\n\021DocumentDirection\030\002 \001(\0162#.Diadoc.Api.P" +
@@ -14946,57 +14946,58 @@ public final class DocumentInfoProtos {
       "ocumentInfo\022b\n\037UniversalCorrectionDocume" +
       "ntInfo\030\020 \001(\01329.Diadoc.Api.Proto.Docflow." +
       "UniversalCorrectionDocumentInfo\022\031\n\021Attac" +
-      "hmentVersion\030\021 \001(\t\022\017\n\007Version\030\022 \002(\t\"E\n\025D" +
-      "ocumentDateAndNumber\022\024\n\014DocumentDate\030\001 \001" +
-      "(\t\022\026\n\016DocumentNumber\030\002 \001(\t\"\237\001\n\021BasicDocu" +
-      "mentInfo\022\r\n\005Total\030\001 \001(\t\022\r\n\005NoVat\030\002 \001(\010\022\013" +
-      "\n\003Vat\030\003 \001(\t\022\017\n\007Grounds\030\004 \001(\t\022N\n\025Revision" +
-      "DateAndNumber\030\005 \001(\0132/.Diadoc.Api.Proto.D" +
-      "ocflow.DocumentDateAndNumber\"\236\001\n\023Invoice" +
-      "DocumentInfo\022\r\n\005Total\030\001 \001(\t\022\013\n\003Vat\030\002 \001(\t" +
-      "\022\024\n\014CurrencyCode\030\003 \001(\005\022U\n\034OriginalInvoic" +
-      "eDateAndNumber\030\004 \001(\0132/.Diadoc.Api.Proto." +
-      "Docflow.DocumentDateAndNumber\"\220\003\n\035Invoic" +
-      "eCorrectionDocumentInfo\022\020\n\010TotalInc\030\001 \001(" +
-      "\t\022\020\n\010TotalDec\030\002 \001(\t\022\016\n\006VatInc\030\003 \001(\t\022\016\n\006V" +
-      "atDec\030\004 \001(\t\022\024\n\014CurrencyCode\030\005 \001(\005\022U\n\034Ori" +
-      "ginalInvoiceDateAndNumber\030\006 \001(\0132/.Diadoc" +
-      ".Api.Proto.Docflow.DocumentDateAndNumber" +
-      "\022]\n$OriginalInvoiceRevisionDateAndNumber" +
-      "\030\007 \001(\0132/.Diadoc.Api.Proto.Docflow.Docume" +
-      "ntDateAndNumber\022_\n&OriginalInvoiceCorrec" +
-      "tionDateAndNumber\030\010 \001(\0132/.Diadoc.Api.Pro" +
-      "to.Docflow.DocumentDateAndNumber\"\217\001\n\025Pri" +
-      "ceListDocumentInfo\022\036\n\026PriceListEffective" +
-      "Date\030\001 \001(\t\022V\n\035ContractDocumentDateAndNum" +
-      "ber\030\002 \001(\0132/.Diadoc.Api.Proto.Docflow.Doc" +
-      "umentDateAndNumber\"C\n\024ContractDocumentIn" +
-      "fo\022\025\n\rContractPrice\030\001 \001(\t\022\024\n\014ContractTyp" +
-      "e\030\002 \001(\t\"\361\001\n\"SupplementaryAgreementDocume" +
-      "ntInfo\022\024\n\014ContractType\030\001 \001(\t\022V\n\035Contract" +
-      "DocumentDateAndNumber\030\002 \002(\0132/.Diadoc.Api" +
-      ".Proto.Docflow.DocumentDateAndNumber\022N\n\025" +
-      "DocumentDateAndNumber\030\003 \002(\0132/.Diadoc.Api" +
-      ".Proto.Docflow.DocumentDateAndNumber\022\r\n\005" +
-      "Total\030\004 \001(\t\"\366\001\n\035UniversalTransferDocumen" +
-      "tInfo\022\r\n\005Total\030\001 \001(\t\022\013\n\003Vat\030\002 \001(\t\022\024\n\014Cur" +
-      "rencyCode\030\003 \001(\005\022\017\n\007Grounds\030\004 \001(\t\022:\n\010Func" +
-      "tion\030\005 \002(\0162(.Diadoc.Api.Proto.Invoicing." +
-      "FunctionType\022V\n\035OriginalDocumentDateAndN" +
-      "umber\030\006 \001(\0132/.Diadoc.Api.Proto.Docflow.D" +
-      "ocumentDateAndNumber\"\342\003\n\037UniversalCorrec" +
-      "tionDocumentInfo\022\020\n\010TotalInc\030\001 \001(\t\022\020\n\010To" +
-      "talDec\030\002 \001(\t\022\016\n\006VatInc\030\003 \001(\t\022\016\n\006VatDec\030\004" +
-      " \001(\t\022\024\n\014CurrencyCode\030\005 \001(\005\022\017\n\007Grounds\030\006 " +
-      "\001(\t\022:\n\010Function\030\007 \002(\0162(.Diadoc.Api.Proto" +
-      ".Invoicing.FunctionType\022V\n\035OriginalDocum" +
-      "entDateAndNumber\030\010 \001(\0132/.Diadoc.Api.Prot" +
-      "o.Docflow.DocumentDateAndNumber\022^\n%Origi" +
-      "nalDocumentRevisionDateAndNumber\030\t \001(\0132/" +
-      ".Diadoc.Api.Proto.Docflow.DocumentDateAn" +
-      "dNumber\022`\n\'OriginalDocumentCorrectionDat" +
-      "eAndNumber\030\n \001(\0132/.Diadoc.Api.Proto.Docf" +
-      "low.DocumentDateAndNumberB\024B\022DocumentInf" +
+      "hmentVersion\030\021 \001(\t\022\017\n\007Version\030\022 \002(\t:\002\030\001\"" +
+      "I\n\025DocumentDateAndNumber\022\024\n\014DocumentDate" +
+      "\030\001 \001(\t\022\026\n\016DocumentNumber\030\002 \001(\t:\002\030\001\"\243\001\n\021B" +
+      "asicDocumentInfo\022\r\n\005Total\030\001 \001(\t\022\r\n\005NoVat" +
+      "\030\002 \001(\010\022\013\n\003Vat\030\003 \001(\t\022\017\n\007Grounds\030\004 \001(\t\022N\n\025" +
+      "RevisionDateAndNumber\030\005 \001(\0132/.Diadoc.Api" +
+      ".Proto.Docflow.DocumentDateAndNumber:\002\030\001" +
+      "\"\242\001\n\023InvoiceDocumentInfo\022\r\n\005Total\030\001 \001(\t\022" +
+      "\013\n\003Vat\030\002 \001(\t\022\024\n\014CurrencyCode\030\003 \001(\005\022U\n\034Or" +
+      "iginalInvoiceDateAndNumber\030\004 \001(\0132/.Diado" +
+      "c.Api.Proto.Docflow.DocumentDateAndNumbe" +
+      "r:\002\030\001\"\224\003\n\035InvoiceCorrectionDocumentInfo\022" +
+      "\020\n\010TotalInc\030\001 \001(\t\022\020\n\010TotalDec\030\002 \001(\t\022\016\n\006V" +
+      "atInc\030\003 \001(\t\022\016\n\006VatDec\030\004 \001(\t\022\024\n\014CurrencyC" +
+      "ode\030\005 \001(\005\022U\n\034OriginalInvoiceDateAndNumbe" +
+      "r\030\006 \001(\0132/.Diadoc.Api.Proto.Docflow.Docum" +
+      "entDateAndNumber\022]\n$OriginalInvoiceRevis" +
+      "ionDateAndNumber\030\007 \001(\0132/.Diadoc.Api.Prot" +
+      "o.Docflow.DocumentDateAndNumber\022_\n&Origi" +
+      "nalInvoiceCorrectionDateAndNumber\030\010 \001(\0132" +
+      "/.Diadoc.Api.Proto.Docflow.DocumentDateA" +
+      "ndNumber:\002\030\001\"\223\001\n\025PriceListDocumentInfo\022\036" +
+      "\n\026PriceListEffectiveDate\030\001 \001(\t\022V\n\035Contra" +
+      "ctDocumentDateAndNumber\030\002 \001(\0132/.Diadoc.A" +
+      "pi.Proto.Docflow.DocumentDateAndNumber:\002" +
+      "\030\001\"G\n\024ContractDocumentInfo\022\025\n\rContractPr" +
+      "ice\030\001 \001(\t\022\024\n\014ContractType\030\002 \001(\t:\002\030\001\"\365\001\n\"" +
+      "SupplementaryAgreementDocumentInfo\022\024\n\014Co" +
+      "ntractType\030\001 \001(\t\022V\n\035ContractDocumentDate" +
+      "AndNumber\030\002 \002(\0132/.Diadoc.Api.Proto.Docfl" +
+      "ow.DocumentDateAndNumber\022N\n\025DocumentDate" +
+      "AndNumber\030\003 \002(\0132/.Diadoc.Api.Proto.Docfl" +
+      "ow.DocumentDateAndNumber\022\r\n\005Total\030\004 \001(\t:" +
+      "\002\030\001\"\372\001\n\035UniversalTransferDocumentInfo\022\r\n" +
+      "\005Total\030\001 \001(\t\022\013\n\003Vat\030\002 \001(\t\022\024\n\014CurrencyCod" +
+      "e\030\003 \001(\005\022\017\n\007Grounds\030\004 \001(\t\022:\n\010Function\030\005 \002" +
+      "(\0162(.Diadoc.Api.Proto.Invoicing.Function" +
+      "Type\022V\n\035OriginalDocumentDateAndNumber\030\006 " +
+      "\001(\0132/.Diadoc.Api.Proto.Docflow.DocumentD" +
+      "ateAndNumber:\002\030\001\"\346\003\n\037UniversalCorrection" +
+      "DocumentInfo\022\020\n\010TotalInc\030\001 \001(\t\022\020\n\010TotalD" +
+      "ec\030\002 \001(\t\022\016\n\006VatInc\030\003 \001(\t\022\016\n\006VatDec\030\004 \001(\t" +
+      "\022\024\n\014CurrencyCode\030\005 \001(\005\022\017\n\007Grounds\030\006 \001(\t\022" +
+      ":\n\010Function\030\007 \002(\0162(.Diadoc.Api.Proto.Inv" +
+      "oicing.FunctionType\022V\n\035OriginalDocumentD" +
+      "ateAndNumber\030\010 \001(\0132/.Diadoc.Api.Proto.Do" +
+      "cflow.DocumentDateAndNumber\022^\n%OriginalD" +
+      "ocumentRevisionDateAndNumber\030\t \001(\0132/.Dia" +
+      "doc.Api.Proto.Docflow.DocumentDateAndNum" +
+      "ber\022`\n\'OriginalDocumentCorrectionDateAnd" +
+      "Number\030\n \001(\0132/.Diadoc.Api.Proto.Docflow." +
+      "DocumentDateAndNumber:\002\030\001B\024B\022DocumentInf" +
       "oProtos"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor

--- a/src/main/java/Diadoc/Api/Proto/Docflow/DocumentWithDocflowProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Docflow/DocumentWithDocflowProtos.java
@@ -5,7 +5,7 @@
 
 package Diadoc.Api.Proto.Docflow;
 
-public final class DocumentWithDocflowProtos {
+@java.lang.Deprecated public final class DocumentWithDocflowProtos {
   private DocumentWithDocflowProtos() {}
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
@@ -25,7 +25,7 @@ public final class DocumentWithDocflowProtos {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
-  public interface DocumentWithDocflowOrBuilder extends
+  @java.lang.Deprecated public interface DocumentWithDocflowOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.DocumentWithDocflow)
       com.google.protobuf.MessageOrBuilder {
 
@@ -181,7 +181,7 @@ public final class DocumentWithDocflowProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.DocumentWithDocflow}
    */
-  public static final class DocumentWithDocflow extends
+  @java.lang.Deprecated public static final class DocumentWithDocflow extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.DocumentWithDocflow)
       DocumentWithDocflowOrBuilder {
@@ -2596,7 +2596,7 @@ public final class DocumentWithDocflowProtos {
       "doc.Api.Proto.Docflow\032\017Timestamp.proto\032\020" +
       "DocumentId.proto\032\032ForwardDocumentEvent.p" +
       "roto\032\025Docflow/Docflow.proto\032\032Docflow/Doc" +
-      "umentInfo.proto\"\306\003\n\023DocumentWithDocflow\022" +
+      "umentInfo.proto\"\312\003\n\023DocumentWithDocflow\022" +
       "0\n\nDocumentId\030\001 \001(\0132\034.Diadoc.Api.Proto.D" +
       "ocumentId\022\023\n\013LastEventId\030\002 \001(\t\0227\n\022LastEv" +
       "entTimestamp\030\003 \001(\0132\033.Diadoc.Api.Proto.Ti" +
@@ -2607,8 +2607,8 @@ public final class DocumentWithDocflowProtos {
       "pi.Proto.DocumentId\022<\n\026SubordinateDocume" +
       "ntIds\030\007 \003(\0132\034.Diadoc.Api.Proto.DocumentI" +
       "d\022E\n\025ForwardDocumentEvents\030\010 \003(\0132&.Diado" +
-      "c.Api.Proto.ForwardDocumentEventB\033B\031Docu" +
-      "mentWithDocflowProtos"
+      "c.Api.Proto.ForwardDocumentEvent:\002\030\001B\036B\031" +
+      "DocumentWithDocflowProtos\270\001\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/src/main/java/Diadoc/Api/Proto/Docflow/InvoiceDocflowProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Docflow/InvoiceDocflowProtos.java
@@ -25,7 +25,7 @@ public final class InvoiceDocflowProtos {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
-  public interface InboundInvoiceDocflowOrBuilder extends
+  @java.lang.Deprecated public interface InboundInvoiceDocflowOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.InboundInvoiceDocflow)
       com.google.protobuf.MessageOrBuilder {
 
@@ -136,7 +136,7 @@ public final class InvoiceDocflowProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.InboundInvoiceDocflow}
    */
-  public static final class InboundInvoiceDocflow extends
+  @java.lang.Deprecated public static final class InboundInvoiceDocflow extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.InboundInvoiceDocflow)
       InboundInvoiceDocflowOrBuilder {
@@ -1639,7 +1639,7 @@ public final class InvoiceDocflowProtos {
 
   }
 
-  public interface OutboundInvoiceDocflowOrBuilder extends
+  @java.lang.Deprecated public interface OutboundInvoiceDocflowOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.OutboundInvoiceDocflow)
       com.google.protobuf.MessageOrBuilder {
 
@@ -1761,7 +1761,7 @@ public final class InvoiceDocflowProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.OutboundInvoiceDocflow}
    */
-  public static final class OutboundInvoiceDocflow extends
+  @java.lang.Deprecated public static final class OutboundInvoiceDocflow extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.OutboundInvoiceDocflow)
       OutboundInvoiceDocflowOrBuilder {
@@ -3353,7 +3353,7 @@ public final class InvoiceDocflowProtos {
 
   }
 
-  public interface InvoiceConfirmationDocflowOrBuilder extends
+  @java.lang.Deprecated public interface InvoiceConfirmationDocflowOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.InvoiceConfirmationDocflow)
       com.google.protobuf.MessageOrBuilder {
 
@@ -3401,7 +3401,7 @@ public final class InvoiceDocflowProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.InvoiceConfirmationDocflow}
    */
-  public static final class InvoiceConfirmationDocflow extends
+  @java.lang.Deprecated public static final class InvoiceConfirmationDocflow extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.InvoiceConfirmationDocflow)
       InvoiceConfirmationDocflowOrBuilder {
@@ -4245,7 +4245,7 @@ public final class InvoiceDocflowProtos {
 
   }
 
-  public interface InboundInvoiceReceiptDocflowOrBuilder extends
+  @java.lang.Deprecated public interface InboundInvoiceReceiptDocflowOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.InboundInvoiceReceiptDocflow)
       com.google.protobuf.MessageOrBuilder {
 
@@ -4293,7 +4293,7 @@ public final class InvoiceDocflowProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.InboundInvoiceReceiptDocflow}
    */
-  public static final class InboundInvoiceReceiptDocflow extends
+  @java.lang.Deprecated public static final class InboundInvoiceReceiptDocflow extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.InboundInvoiceReceiptDocflow)
       InboundInvoiceReceiptDocflowOrBuilder {
@@ -5137,7 +5137,7 @@ public final class InvoiceDocflowProtos {
 
   }
 
-  public interface InvoiceCorrectionRequestDocflowOrBuilder extends
+  @java.lang.Deprecated public interface InvoiceCorrectionRequestDocflowOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.InvoiceCorrectionRequestDocflow)
       com.google.protobuf.MessageOrBuilder {
 
@@ -5185,7 +5185,7 @@ public final class InvoiceDocflowProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.InvoiceCorrectionRequestDocflow}
    */
-  public static final class InvoiceCorrectionRequestDocflow extends
+  @java.lang.Deprecated public static final class InvoiceCorrectionRequestDocflow extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.InvoiceCorrectionRequestDocflow)
       InvoiceCorrectionRequestDocflowOrBuilder {
@@ -6066,7 +6066,7 @@ public final class InvoiceDocflowProtos {
       "\n\034Docflow/InvoiceDocflow.proto\022\030Diadoc.A" +
       "pi.Proto.Docflow\032\017Timestamp.proto\032\030Docfl" +
       "ow/Attachment.proto\032\034Docflow/ReceiptDocf" +
-      "low.proto\"\255\003\n\025InboundInvoiceDocflow\022\022\n\nI" +
+      "low.proto\"\261\003\n\025InboundInvoiceDocflow\022\022\n\nI" +
       "sFinished\030\001 \001(\010\022N\n\016ReceiptDocflow\030\002 \001(\0132" +
       "6.Diadoc.Api.Proto.Docflow.InboundInvoic" +
       "eReceiptDocflow\022Q\n\023ConfirmationDocflow\030\003" +
@@ -6077,34 +6077,34 @@ public final class InvoiceDocflowProtos {
       "rmationTimestamp\030\005 \001(\0132\033.Diadoc.Api.Prot" +
       "o.Timestamp\022\034\n\024IsAmendmentRequested\030\006 \001(" +
       "\010\022\021\n\tIsRevised\030\007 \001(\010\022\023\n\013IsCorrected\030\010 \001(" +
-      "\010\"\305\003\n\026OutboundInvoiceDocflow\022\022\n\nIsFinish" +
-      "ed\030\001 \001(\010\022@\n\016ReceiptDocflow\030\002 \001(\0132(.Diado" +
-      "c.Api.Proto.Docflow.ReceiptDocflow\022Q\n\023Co" +
-      "nfirmationDocflow\030\003 \001(\01324.Diadoc.Api.Pro" +
-      "to.Docflow.InvoiceConfirmationDocflow\022[\n" +
-      "\030CorrectionRequestDocflow\030\004 \001(\01329.Diadoc" +
-      ".Api.Proto.Docflow.InvoiceCorrectionRequ" +
-      "estDocflow\022:\n\025ConfirmationTimestamp\030\005 \001(" +
-      "\0132\033.Diadoc.Api.Proto.Timestamp\022\034\n\024IsAmen" +
-      "dmentRequested\030\006 \001(\010\022\021\n\tIsRevised\030\007 \001(\010\022" +
-      "\023\n\013IsCorrected\030\010 \001(\010\022#\n\033CanDocumentBeSig" +
-      "nedBySender\030\t \001(\010\"\276\001\n\032InvoiceConfirmatio" +
-      "nDocflow\022\022\n\nIsFinished\030\001 \001(\010\022J\n\026Confirma" +
-      "tionAttachment\030\002 \001(\0132*.Diadoc.Api.Proto." +
-      "Docflow.SignedAttachment\022@\n\016ReceiptDocfl" +
-      "ow\030\003 \001(\0132(.Diadoc.Api.Proto.Docflow.Rece" +
-      "iptDocflow\"\314\001\n\034InboundInvoiceReceiptDocf" +
-      "low\022\022\n\nIsFinished\030\001 \001(\010\022E\n\021ReceiptAttach" +
-      "ment\030\002 \001(\0132*.Diadoc.Api.Proto.Docflow.Si" +
-      "gnedAttachment\022Q\n\023ConfirmationDocflow\030\003 " +
-      "\001(\01324.Diadoc.Api.Proto.Docflow.InvoiceCo" +
-      "nfirmationDocflow\"\310\001\n\037InvoiceCorrectionR" +
-      "equestDocflow\022\022\n\nIsFinished\030\001 \001(\010\022O\n\033Cor" +
-      "rectionRequestAttachment\030\002 \001(\0132*.Diadoc." +
-      "Api.Proto.Docflow.SignedAttachment\022@\n\016Re" +
-      "ceiptDocflow\030\003 \001(\0132(.Diadoc.Api.Proto.Do" +
-      "cflow.ReceiptDocflowB\026B\024InvoiceDocflowPr" +
-      "otos"
+      "\010:\002\030\001\"\311\003\n\026OutboundInvoiceDocflow\022\022\n\nIsFi" +
+      "nished\030\001 \001(\010\022@\n\016ReceiptDocflow\030\002 \001(\0132(.D" +
+      "iadoc.Api.Proto.Docflow.ReceiptDocflow\022Q" +
+      "\n\023ConfirmationDocflow\030\003 \001(\01324.Diadoc.Api" +
+      ".Proto.Docflow.InvoiceConfirmationDocflo" +
+      "w\022[\n\030CorrectionRequestDocflow\030\004 \001(\01329.Di" +
+      "adoc.Api.Proto.Docflow.InvoiceCorrection" +
+      "RequestDocflow\022:\n\025ConfirmationTimestamp\030" +
+      "\005 \001(\0132\033.Diadoc.Api.Proto.Timestamp\022\034\n\024Is" +
+      "AmendmentRequested\030\006 \001(\010\022\021\n\tIsRevised\030\007 " +
+      "\001(\010\022\023\n\013IsCorrected\030\010 \001(\010\022#\n\033CanDocumentB" +
+      "eSignedBySender\030\t \001(\010:\002\030\001\"\302\001\n\032InvoiceCon" +
+      "firmationDocflow\022\022\n\nIsFinished\030\001 \001(\010\022J\n\026" +
+      "ConfirmationAttachment\030\002 \001(\0132*.Diadoc.Ap" +
+      "i.Proto.Docflow.SignedAttachment\022@\n\016Rece" +
+      "iptDocflow\030\003 \001(\0132(.Diadoc.Api.Proto.Docf" +
+      "low.ReceiptDocflow:\002\030\001\"\320\001\n\034InboundInvoic" +
+      "eReceiptDocflow\022\022\n\nIsFinished\030\001 \001(\010\022E\n\021R" +
+      "eceiptAttachment\030\002 \001(\0132*.Diadoc.Api.Prot" +
+      "o.Docflow.SignedAttachment\022Q\n\023Confirmati" +
+      "onDocflow\030\003 \001(\01324.Diadoc.Api.Proto.Docfl" +
+      "ow.InvoiceConfirmationDocflow:\002\030\001\"\314\001\n\037In" +
+      "voiceCorrectionRequestDocflow\022\022\n\nIsFinis" +
+      "hed\030\001 \001(\010\022O\n\033CorrectionRequestAttachment" +
+      "\030\002 \001(\0132*.Diadoc.Api.Proto.Docflow.Signed" +
+      "Attachment\022@\n\016ReceiptDocflow\030\003 \001(\0132(.Dia" +
+      "doc.Api.Proto.Docflow.ReceiptDocflow:\002\030\001" +
+      "B\026B\024InvoiceDocflowProtos"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/src/main/java/Diadoc/Api/Proto/Docflow/ReceiptDocflowProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Docflow/ReceiptDocflowProtos.java
@@ -25,7 +25,7 @@ public final class ReceiptDocflowProtos {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
-  public interface ReceiptDocflowOrBuilder extends
+  @java.lang.Deprecated public interface ReceiptDocflowOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.ReceiptDocflow)
       com.google.protobuf.MessageOrBuilder {
 
@@ -58,7 +58,7 @@ public final class ReceiptDocflowProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.ReceiptDocflow}
    */
-  public static final class ReceiptDocflow extends
+  @java.lang.Deprecated public static final class ReceiptDocflow extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.ReceiptDocflow)
       ReceiptDocflowOrBuilder {
@@ -722,10 +722,10 @@ public final class ReceiptDocflowProtos {
     java.lang.String[] descriptorData = {
       "\n\034Docflow/ReceiptDocflow.proto\022\030Diadoc.A" +
       "pi.Proto.Docflow\032\030Docflow/Attachment.pro" +
-      "to\"k\n\016ReceiptDocflow\022\022\n\nIsFinished\030\001 \001(\010" +
+      "to\"o\n\016ReceiptDocflow\022\022\n\nIsFinished\030\001 \001(\010" +
       "\022E\n\021ReceiptAttachment\030\002 \001(\0132*.Diadoc.Api" +
-      ".Proto.Docflow.SignedAttachmentB\026B\024Recei" +
-      "ptDocflowProtos"
+      ".Proto.Docflow.SignedAttachment:\002\030\001B\026B\024R" +
+      "eceiptDocflowProtos"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/src/main/java/Diadoc/Api/Proto/Docflow/RecipientSignatureDocflowProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Docflow/RecipientSignatureDocflowProtos.java
@@ -25,7 +25,7 @@ public final class RecipientSignatureDocflowProtos {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
-  public interface RecipientSignatureDocflowOrBuilder extends
+  @java.lang.Deprecated public interface RecipientSignatureDocflowOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.RecipientSignatureDocflow)
       com.google.protobuf.MessageOrBuilder {
 
@@ -73,7 +73,7 @@ public final class RecipientSignatureDocflowProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.RecipientSignatureDocflow}
    */
-  public static final class RecipientSignatureDocflow extends
+  @java.lang.Deprecated public static final class RecipientSignatureDocflow extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.RecipientSignatureDocflow)
       RecipientSignatureDocflowOrBuilder {
@@ -933,12 +933,12 @@ public final class RecipientSignatureDocflowProtos {
     java.lang.String[] descriptorData = {
       "\n\'Docflow/RecipientSignatureDocflow.prot" +
       "o\022\030Diadoc.Api.Proto.Docflow\032\017Timestamp.p" +
-      "roto\032\030Docflow/Attachment.proto\"\250\001\n\031Recip" +
+      "roto\032\030Docflow/Attachment.proto\"\254\001\n\031Recip" +
       "ientSignatureDocflow\022\022\n\nIsFinished\030\001 \001(\010" +
       "\022?\n\022RecipientSignature\030\002 \001(\0132#.Diadoc.Ap" +
       "i.Proto.Docflow.Signature\0226\n\021DeliveryTim" +
       "estamp\030\003 \001(\0132\033.Diadoc.Api.Proto.Timestam" +
-      "pB!B\037RecipientSignatureDocflowProtos"
+      "p:\002\030\001B!B\037RecipientSignatureDocflowProtos"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/src/main/java/Diadoc/Api/Proto/Docflow/RecipientSignatureRejectionDocflowProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Docflow/RecipientSignatureRejectionDocflowProtos.java
@@ -5,7 +5,7 @@
 
 package Diadoc.Api.Proto.Docflow;
 
-public final class RecipientSignatureRejectionDocflowProtos {
+@java.lang.Deprecated public final class RecipientSignatureRejectionDocflowProtos {
   private RecipientSignatureRejectionDocflowProtos() {}
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
@@ -25,7 +25,7 @@ public final class RecipientSignatureRejectionDocflowProtos {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
-  public interface RecipientSignatureRejectionDocflowOrBuilder extends
+  @java.lang.Deprecated public interface RecipientSignatureRejectionDocflowOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.RecipientSignatureRejectionDocflow)
       com.google.protobuf.MessageOrBuilder {
 
@@ -73,7 +73,7 @@ public final class RecipientSignatureRejectionDocflowProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.RecipientSignatureRejectionDocflow}
    */
-  public static final class RecipientSignatureRejectionDocflow extends
+  @java.lang.Deprecated public static final class RecipientSignatureRejectionDocflow extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.RecipientSignatureRejectionDocflow)
       RecipientSignatureRejectionDocflowOrBuilder {
@@ -934,13 +934,13 @@ public final class RecipientSignatureRejectionDocflowProtos {
       "\n0Docflow/RecipientSignatureRejectionDoc" +
       "flow.proto\022\030Diadoc.Api.Proto.Docflow\032\017Ti" +
       "mestamp.proto\032\030Docflow/Attachment.proto\"" +
-      "\313\001\n\"RecipientSignatureRejectionDocflow\022\022" +
+      "\317\001\n\"RecipientSignatureRejectionDocflow\022\022" +
       "\n\nIsFinished\030\001 \001(\010\022Y\n%RecipientSignature" +
       "RejectionAttachment\030\002 \001(\0132*.Diadoc.Api.P" +
       "roto.Docflow.SignedAttachment\0226\n\021Deliver" +
       "yTimestamp\030\003 \001(\0132\033.Diadoc.Api.Proto.Time" +
-      "stampB*B(RecipientSignatureRejectionDocf" +
-      "lowProtos"
+      "stamp:\002\030\001B-B(RecipientSignatureRejection" +
+      "DocflowProtos\270\001\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/src/main/java/Diadoc/Api/Proto/Docflow/RevocationDocflowProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Docflow/RevocationDocflowProtos.java
@@ -5,7 +5,7 @@
 
 package Diadoc.Api.Proto.Docflow;
 
-public final class RevocationDocflowProtos {
+@java.lang.Deprecated public final class RevocationDocflowProtos {
   private RevocationDocflowProtos() {}
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
@@ -25,7 +25,7 @@ public final class RevocationDocflowProtos {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
-  public interface RevocationDocflowOrBuilder extends
+  @java.lang.Deprecated public interface RevocationDocflowOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.RevocationDocflow)
       com.google.protobuf.MessageOrBuilder {
 
@@ -127,7 +127,7 @@ public final class RevocationDocflowProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.RevocationDocflow}
    */
-  public static final class RevocationDocflow extends
+  @java.lang.Deprecated public static final class RevocationDocflow extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.RevocationDocflow)
       RevocationDocflowOrBuilder {
@@ -1523,7 +1523,7 @@ public final class RevocationDocflowProtos {
       "c.Api.Proto.Docflow\032\030Docflow/Attachment." +
       "proto\032\'Docflow/RecipientSignatureDocflow" +
       ".proto\0320Docflow/RecipientSignatureReject" +
-      "ionDocflow.proto\"\216\003\n\021RevocationDocflow\022\022" +
+      "ionDocflow.proto\"\222\003\n\021RevocationDocflow\022\022" +
       "\n\nIsFinished\030\001 \001(\010\022O\n\033RevocationRequestA" +
       "ttachment\030\002 \001(\0132*.Diadoc.Api.Proto.Docfl" +
       "ow.SignedAttachment\022V\n\031RecipientSignatur" +
@@ -1533,8 +1533,8 @@ public final class RevocationDocflowProtos {
       ".Api.Proto.Docflow.RecipientSignatureRej" +
       "ectionDocflow\022\026\n\016InitiatorBoxId\030\005 \001(\t\022\034\n" +
       "\024IsRevocationAccepted\030\006 \001(\010\022\034\n\024IsRevocat" +
-      "ionRejected\030\007 \001(\010B\031B\027RevocationDocflowPr" +
-      "otos"
+      "ionRejected\030\007 \001(\010:\002\030\001B\034B\027RevocationDocfl" +
+      "owProtos\270\001\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/src/main/java/Diadoc/Api/Proto/Docflow/UnilateralDocflowProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Docflow/UnilateralDocflowProtos.java
@@ -5,7 +5,7 @@
 
 package Diadoc.Api.Proto.Docflow;
 
-public final class UnilateralDocflowProtos {
+@java.lang.Deprecated public final class UnilateralDocflowProtos {
   private UnilateralDocflowProtos() {}
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
@@ -25,7 +25,7 @@ public final class UnilateralDocflowProtos {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
-  public interface UnilateralDocflowOrBuilder extends
+  @java.lang.Deprecated public interface UnilateralDocflowOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.UnilateralDocflow)
       com.google.protobuf.MessageOrBuilder {
 
@@ -91,7 +91,7 @@ public final class UnilateralDocflowProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.UnilateralDocflow}
    */
-  public static final class UnilateralDocflow extends
+  @java.lang.Deprecated public static final class UnilateralDocflow extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.UnilateralDocflow)
       UnilateralDocflowOrBuilder {
@@ -1022,13 +1022,13 @@ public final class UnilateralDocflowProtos {
     java.lang.String[] descriptorData = {
       "\n\037Docflow/UnilateralDocflow.proto\022\030Diado" +
       "c.Api.Proto.Docflow\032\034Docflow/ReceiptDocf" +
-      "low.proto\"\312\001\n\021UnilateralDocflow\022\022\n\nIsFin" +
+      "low.proto\"\316\001\n\021UnilateralDocflow\022\022\n\nIsFin" +
       "ished\030\001 \001(\010\022@\n\016ReceiptDocflow\030\002 \001(\0132(.Di" +
       "adoc.Api.Proto.Docflow.ReceiptDocflow\022\032\n" +
       "\022IsReceiptRequested\030\003 \001(\010\022\036\n\026CanDocument" +
       "BeReceipted\030\004 \001(\010\022#\n\033CanDocumentBeSigned" +
-      "BySender\030\005 \001(\010B\031B\027UnilateralDocflowProto" +
-      "s"
+      "BySender\030\005 \001(\010:\002\030\001B\034B\027UnilateralDocflowP" +
+      "rotos\270\001\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/src/main/java/Diadoc/Api/Proto/Docflow/UniversalTransferDocumentDocflowProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Docflow/UniversalTransferDocumentDocflowProtos.java
@@ -5,7 +5,7 @@
 
 package Diadoc.Api.Proto.Docflow;
 
-public final class UniversalTransferDocumentDocflowProtos {
+@java.lang.Deprecated public final class UniversalTransferDocumentDocflowProtos {
   private UniversalTransferDocumentDocflowProtos() {}
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
@@ -25,7 +25,7 @@ public final class UniversalTransferDocumentDocflowProtos {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
-  public interface InboundUniversalTransferDocumentDocflowOrBuilder extends
+  @java.lang.Deprecated public interface InboundUniversalTransferDocumentDocflowOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.InboundUniversalTransferDocumentDocflow)
       com.google.protobuf.MessageOrBuilder {
 
@@ -232,7 +232,7 @@ public final class UniversalTransferDocumentDocflowProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.InboundUniversalTransferDocumentDocflow}
    */
-  public static final class InboundUniversalTransferDocumentDocflow extends
+  @java.lang.Deprecated public static final class InboundUniversalTransferDocumentDocflow extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.InboundUniversalTransferDocumentDocflow)
       InboundUniversalTransferDocumentDocflowOrBuilder {
@@ -2661,7 +2661,7 @@ public final class UniversalTransferDocumentDocflowProtos {
 
   }
 
-  public interface OutboundUniversalTransferDocumentDocflowOrBuilder extends
+  @java.lang.Deprecated public interface OutboundUniversalTransferDocumentDocflowOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.OutboundUniversalTransferDocumentDocflow)
       com.google.protobuf.MessageOrBuilder {
 
@@ -2879,7 +2879,7 @@ public final class UniversalTransferDocumentDocflowProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.OutboundUniversalTransferDocumentDocflow}
    */
-  public static final class OutboundUniversalTransferDocumentDocflow extends
+  @java.lang.Deprecated public static final class OutboundUniversalTransferDocumentDocflow extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.OutboundUniversalTransferDocumentDocflow)
       OutboundUniversalTransferDocumentDocflowOrBuilder {
@@ -5422,7 +5422,7 @@ public final class UniversalTransferDocumentDocflowProtos {
       "ocflow/ReceiptDocflow.proto\032!Docflow/Xml" +
       "BilateralDocflow.proto\0320Docflow/Recipien" +
       "tSignatureRejectionDocflow.proto\032\034Docflo" +
-      "w/InvoiceDocflow.proto\"\322\006\n\'InboundUniver" +
+      "w/InvoiceDocflow.proto\"\326\006\n\'InboundUniver" +
       "salTransferDocumentDocflow\022\022\n\nIsFinished" +
       "\030\001 \001(\010\022N\n\016ReceiptDocflow\030\002 \001(\01326.Diadoc." +
       "Api.Proto.Docflow.InboundInvoiceReceiptD" +
@@ -5443,30 +5443,31 @@ public final class UniversalTransferDocumentDocflowProtos {
       "\033IsDocumentSignedByRecipient\030\r \001(\010\022%\n\035Is" +
       "DocumentRejectedByRecipient\030\016 \001(\010\022\036\n\026Can" +
       "DocumentBeReceipted\030\017 \001(\010\0220\n(CanDocument" +
-      "BeSignedOrRejectedByRecipient\030\020 \001(\010\"\352\006\n(" +
-      "OutboundUniversalTransferDocumentDocflow" +
-      "\022\022\n\nIsFinished\030\001 \001(\010\022@\n\016ReceiptDocflow\030\002" +
-      " \001(\0132(.Diadoc.Api.Proto.Docflow.ReceiptD" +
-      "ocflow\022Q\n\023ConfirmationDocflow\030\003 \001(\01324.Di" +
-      "adoc.Api.Proto.Docflow.InvoiceConfirmati" +
-      "onDocflow\022[\n\030CorrectionRequestDocflow\030\004 " +
-      "\001(\01329.Diadoc.Api.Proto.Docflow.InvoiceCo" +
-      "rrectionRequestDocflow\022:\n\025ConfirmationTi" +
-      "mestamp\030\005 \001(\0132\033.Diadoc.Api.Proto.Timesta" +
-      "mp\022\034\n\024IsAmendmentRequested\030\006 \001(\010\022\021\n\tIsRe" +
-      "vised\030\007 \001(\010\022\023\n\013IsCorrected\030\010 \001(\010\022#\n\033CanD" +
-      "ocumentBeSignedBySender\030\t \001(\010\022F\n\021BuyerTi" +
-      "tleDocflow\030\n \001(\0132+.Diadoc.Api.Proto.Docf" +
-      "low.BuyerTitleDocflow\022h\n\"RecipientSignat" +
-      "ureRejectionDocflow\030\013 \001(\0132<.Diadoc.Api.P" +
-      "roto.Docflow.RecipientSignatureRejection" +
-      "Docflow\022\032\n\022IsReceiptRequested\030\014 \001(\010\022%\n\035I" +
-      "sRecipientSignatureRequested\030\r \001(\010\022#\n\033Is" +
-      "DocumentSignedByRecipient\030\016 \001(\010\022%\n\035IsDoc" +
-      "umentRejectedByRecipient\030\017 \001(\010\022\036\n\026CanDoc" +
-      "umentBeReceipted\030\020 \001(\010\0220\n(CanDocumentBeS" +
-      "ignedOrRejectedByRecipient\030\021 \001(\010B(B&Univ" +
-      "ersalTransferDocumentDocflowProtos"
+      "BeSignedOrRejectedByRecipient\030\020 \001(\010:\002\030\001\"" +
+      "\356\006\n(OutboundUniversalTransferDocumentDoc" +
+      "flow\022\022\n\nIsFinished\030\001 \001(\010\022@\n\016ReceiptDocfl" +
+      "ow\030\002 \001(\0132(.Diadoc.Api.Proto.Docflow.Rece" +
+      "iptDocflow\022Q\n\023ConfirmationDocflow\030\003 \001(\0132" +
+      "4.Diadoc.Api.Proto.Docflow.InvoiceConfir" +
+      "mationDocflow\022[\n\030CorrectionRequestDocflo" +
+      "w\030\004 \001(\01329.Diadoc.Api.Proto.Docflow.Invoi" +
+      "ceCorrectionRequestDocflow\022:\n\025Confirmati" +
+      "onTimestamp\030\005 \001(\0132\033.Diadoc.Api.Proto.Tim" +
+      "estamp\022\034\n\024IsAmendmentRequested\030\006 \001(\010\022\021\n\t" +
+      "IsRevised\030\007 \001(\010\022\023\n\013IsCorrected\030\010 \001(\010\022#\n\033" +
+      "CanDocumentBeSignedBySender\030\t \001(\010\022F\n\021Buy" +
+      "erTitleDocflow\030\n \001(\0132+.Diadoc.Api.Proto." +
+      "Docflow.BuyerTitleDocflow\022h\n\"RecipientSi" +
+      "gnatureRejectionDocflow\030\013 \001(\0132<.Diadoc.A" +
+      "pi.Proto.Docflow.RecipientSignatureRejec" +
+      "tionDocflow\022\032\n\022IsReceiptRequested\030\014 \001(\010\022" +
+      "%\n\035IsRecipientSignatureRequested\030\r \001(\010\022#" +
+      "\n\033IsDocumentSignedByRecipient\030\016 \001(\010\022%\n\035I" +
+      "sDocumentRejectedByRecipient\030\017 \001(\010\022\036\n\026Ca" +
+      "nDocumentBeReceipted\030\020 \001(\010\0220\n(CanDocumen" +
+      "tBeSignedOrRejectedByRecipient\030\021 \001(\010:\002\030\001" +
+      "B+B&UniversalTransferDocumentDocflowProt" +
+      "os\270\001\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/src/main/java/Diadoc/Api/Proto/Docflow/XmlBilateralDocflowProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Docflow/XmlBilateralDocflowProtos.java
@@ -5,7 +5,7 @@
 
 package Diadoc.Api.Proto.Docflow;
 
-public final class XmlBilateralDocflowProtos {
+@java.lang.Deprecated public final class XmlBilateralDocflowProtos {
   private XmlBilateralDocflowProtos() {}
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
@@ -25,7 +25,7 @@ public final class XmlBilateralDocflowProtos {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
-  public interface XmlBilateralDocflowOrBuilder extends
+  @java.lang.Deprecated public interface XmlBilateralDocflowOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.XmlBilateralDocflow)
       com.google.protobuf.MessageOrBuilder {
 
@@ -154,7 +154,7 @@ public final class XmlBilateralDocflowProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.XmlBilateralDocflow}
    */
-  public static final class XmlBilateralDocflow extends
+  @java.lang.Deprecated public static final class XmlBilateralDocflow extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.XmlBilateralDocflow)
       XmlBilateralDocflowOrBuilder {
@@ -1728,7 +1728,7 @@ public final class XmlBilateralDocflowProtos {
 
   }
 
-  public interface BuyerTitleDocflowOrBuilder extends
+  @java.lang.Deprecated public interface BuyerTitleDocflowOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Docflow.BuyerTitleDocflow)
       com.google.protobuf.MessageOrBuilder {
 
@@ -1791,7 +1791,7 @@ public final class XmlBilateralDocflowProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Docflow.BuyerTitleDocflow}
    */
-  public static final class BuyerTitleDocflow extends
+  @java.lang.Deprecated public static final class BuyerTitleDocflow extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Docflow.BuyerTitleDocflow)
       BuyerTitleDocflowOrBuilder {
@@ -2854,7 +2854,7 @@ public final class XmlBilateralDocflowProtos {
       "doc.Api.Proto.Docflow\032\017Timestamp.proto\032\030" +
       "Docflow/Attachment.proto\032\034Docflow/Receip" +
       "tDocflow.proto\0320Docflow/RecipientSignatu" +
-      "reRejectionDocflow.proto\"\374\003\n\023XmlBilatera" +
+      "reRejectionDocflow.proto\"\200\004\n\023XmlBilatera" +
       "lDocflow\022\022\n\nIsFinished\030\001 \001(\010\022@\n\016ReceiptD" +
       "ocflow\030\002 \001(\0132(.Diadoc.Api.Proto.Docflow." +
       "ReceiptDocflow\022F\n\021BuyerTitleDocflow\030\003 \001(" +
@@ -2867,13 +2867,13 @@ public final class XmlBilateralDocflowProtos {
       "yRecipient\030\007 \001(\010\022\036\n\026CanDocumentBeReceipt" +
       "ed\030\010 \001(\010\022#\n\033CanDocumentBeSignedBySender\030" +
       "\t \001(\010\0220\n(CanDocumentBeSignedOrRejectedBy" +
-      "Recipient\030\n \001(\010\"\335\001\n\021BuyerTitleDocflow\022\022\n" +
-      "\nIsFinished\030\001 \001(\010\022H\n\024BuyerTitleAttachmen" +
-      "t\030\002 \001(\0132*.Diadoc.Api.Proto.Docflow.Signe" +
-      "dAttachment\0222\n\rSendTimestamp\030\003 \001(\0132\033.Dia" +
-      "doc.Api.Proto.Timestamp\0226\n\021DeliveryTimes" +
-      "tamp\030\004 \001(\0132\033.Diadoc.Api.Proto.TimestampB" +
-      "\033B\031XmlBilateralDocflowProtos"
+      "Recipient\030\n \001(\010:\002\030\001\"\341\001\n\021BuyerTitleDocflo" +
+      "w\022\022\n\nIsFinished\030\001 \001(\010\022H\n\024BuyerTitleAttac" +
+      "hment\030\002 \001(\0132*.Diadoc.Api.Proto.Docflow.S" +
+      "ignedAttachment\0222\n\rSendTimestamp\030\003 \001(\0132\033" +
+      ".Diadoc.Api.Proto.Timestamp\0226\n\021DeliveryT" +
+      "imestamp\030\004 \001(\0132\033.Diadoc.Api.Proto.Timest" +
+      "amp:\002\030\001B\036B\031XmlBilateralDocflowProtos\270\001\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/src/main/java/Diadoc/Api/Proto/Documents/BilateralDocument/BilateralDocumentProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Documents/BilateralDocument/BilateralDocumentProtos.java
@@ -5578,7 +5578,7 @@ public final class BilateralDocumentProtos {
 
   }
 
-  public interface BilateralDocumentMetadataOrBuilder extends
+  @java.lang.Deprecated public interface BilateralDocumentMetadataOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Documents.BilateralDocument.BilateralDocumentMetadata)
       com.google.protobuf.MessageOrBuilder {
 
@@ -5607,7 +5607,7 @@ public final class BilateralDocumentProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Documents.BilateralDocument.BilateralDocumentMetadata}
    */
-  public static final class BilateralDocumentMetadata extends
+  @java.lang.Deprecated public static final class BilateralDocumentMetadata extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Documents.BilateralDocument.BilateralDocumentMetadata)
       BilateralDocumentMetadataOrBuilder {
@@ -6235,33 +6235,33 @@ public final class BilateralDocumentProtos {
       "ractNumber\030\004 \002(\t\022\024\n\014ContractDate\030\005 \002(\t\022V" +
       "\n\rReceiptStatus\030\006 \001(\0162).Diadoc.Api.Proto" +
       ".Documents.ReceiptStatus:\024UnknownReceipt" +
-      "Status\"\362\001\n\031BilateralDocumentMetadata\022}\n\016" +
+      "Status\"\366\001\n\031BilateralDocumentMetadata\022}\n\016" +
       "DocumentStatus\030\001 \001(\0162E.Diadoc.Api.Proto." +
       "Documents.BilateralDocument.BilateralDoc" +
       "umentStatus:\036UnknownBilateralDocumentSta" +
       "tus\022V\n\rReceiptStatus\030\002 \001(\0162).Diadoc.Api." +
       "Proto.Documents.ReceiptStatus:\024UnknownRe" +
-      "ceiptStatus*\232\006\n\027BilateralDocumentStatus\022" +
-      "\"\n\036UnknownBilateralDocumentStatus\020\000\022(\n$O" +
-      "utboundWaitingForRecipientSignature\020\001\022\"\n" +
-      "\036OutboundWithRecipientSignature\020\002\022+\n\'Out" +
-      "boundWithRecipientPartiallySignature\020\023\022-" +
-      "\n)OutboundRecipientSignatureRequestRejec" +
-      "ted\020\003\022%\n!OutboundWaitingForSenderSignatu" +
-      "re\020\n\022\"\n\036OutboundInvalidSenderSignature\020\013" +
-      "\022\'\n#InboundWaitingForRecipientSignature\020" +
-      "\004\022!\n\035InboundWithRecipientSignature\020\005\022*\n&" +
-      "InboundWithRecipientPartiallySignature\020\024" +
-      "\022,\n(InboundRecipientSignatureRequestReje" +
-      "cted\020\006\022$\n InboundInvalidRecipientSignatu" +
-      "re\020\014\022(\n$InternalWaitingForRecipientSigna" +
-      "ture\020\007\022\"\n\036InternalWithRecipientSignature" +
-      "\020\010\022+\n\'InternalWithRecipientPartiallySign" +
-      "ature\020\025\022-\n)InternalRecipientSignatureReq" +
-      "uestRejected\020\t\022%\n!InternalWaitingForSend" +
-      "erSignature\020\r\022\"\n\036InternalInvalidSenderSi" +
-      "gnature\020\016\022%\n!InternalInvalidRecipientSig" +
-      "nature\020\017B\031B\027BilateralDocumentProtos"
+      "ceiptStatus:\002\030\001*\232\006\n\027BilateralDocumentSta" +
+      "tus\022\"\n\036UnknownBilateralDocumentStatus\020\000\022" +
+      "(\n$OutboundWaitingForRecipientSignature\020" +
+      "\001\022\"\n\036OutboundWithRecipientSignature\020\002\022+\n" +
+      "\'OutboundWithRecipientPartiallySignature" +
+      "\020\023\022-\n)OutboundRecipientSignatureRequestR" +
+      "ejected\020\003\022%\n!OutboundWaitingForSenderSig" +
+      "nature\020\n\022\"\n\036OutboundInvalidSenderSignatu" +
+      "re\020\013\022\'\n#InboundWaitingForRecipientSignat" +
+      "ure\020\004\022!\n\035InboundWithRecipientSignature\020\005" +
+      "\022*\n&InboundWithRecipientPartiallySignatu" +
+      "re\020\024\022,\n(InboundRecipientSignatureRequest" +
+      "Rejected\020\006\022$\n InboundInvalidRecipientSig" +
+      "nature\020\014\022(\n$InternalWaitingForRecipientS" +
+      "ignature\020\007\022\"\n\036InternalWithRecipientSigna" +
+      "ture\020\010\022+\n\'InternalWithRecipientPartially" +
+      "Signature\020\025\022-\n)InternalRecipientSignatur" +
+      "eRequestRejected\020\t\022%\n!InternalWaitingFor" +
+      "SenderSignature\020\r\022\"\n\036InternalInvalidSend" +
+      "erSignature\020\016\022%\n!InternalInvalidRecipien" +
+      "tSignature\020\017B\031B\027BilateralDocumentProtos"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/src/main/java/Diadoc/Api/Proto/Documents/NonformalizedDocument/NonformalizedDocumentProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Documents/NonformalizedDocument/NonformalizedDocumentProtos.java
@@ -291,7 +291,7 @@ public final class NonformalizedDocumentProtos {
     // @@protoc_insertion_point(enum_scope:Diadoc.Api.Proto.Documents.NonformalizedDocument.NonformalizedDocumentStatus)
   }
 
-  public interface NonformalizedDocumentMetadataOrBuilder extends
+  @java.lang.Deprecated public interface NonformalizedDocumentMetadataOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Documents.NonformalizedDocument.NonformalizedDocumentMetadata)
       com.google.protobuf.MessageOrBuilder {
 
@@ -320,7 +320,7 @@ public final class NonformalizedDocumentProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Documents.NonformalizedDocument.NonformalizedDocumentMetadata}
    */
-  public static final class NonformalizedDocumentMetadata extends
+  @java.lang.Deprecated public static final class NonformalizedDocumentMetadata extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Documents.NonformalizedDocument.NonformalizedDocumentMetadata)
       NonformalizedDocumentMetadataOrBuilder {
@@ -887,34 +887,34 @@ public final class NonformalizedDocumentProtos {
       "\n%Documents/NonformalizedDocument.proto\022" +
       "0Diadoc.Api.Proto.Documents.Nonformalize" +
       "dDocument\032\035Documents/ReceiptStatus.proto" +
-      "\"\203\002\n\035NonformalizedDocumentMetadata\022\211\001\n\016D" +
+      "\"\207\002\n\035NonformalizedDocumentMetadata\022\211\001\n\016D" +
       "ocumentStatus\030\001 \001(\0162M.Diadoc.Api.Proto.D" +
       "ocuments.NonformalizedDocument.Nonformal" +
       "izedDocumentStatus:\"UnknownNonformalized" +
       "DocumentStatus\022V\n\rReceiptStatus\030\002 \001(\0162)." +
       "Diadoc.Api.Proto.Documents.ReceiptStatus" +
-      ":\024UnknownReceiptStatus*\226\006\n\033Nonformalized" +
-      "DocumentStatus\022&\n\"UnknownNonformalizedDo" +
-      "cumentStatus\020\000\022\'\n#OutboundNoRecipientSig" +
-      "natureRequest\020\001\022(\n$OutboundWaitingForRec" +
-      "ipientSignature\020\002\022\"\n\036OutboundWithRecipie" +
-      "ntSignature\020\003\022-\n)OutboundRecipientSignat" +
-      "ureRequestRejected\020\004\022%\n!OutboundWaitingF" +
-      "orSenderSignature\020\r\022\"\n\036OutboundInvalidSe" +
-      "nderSignature\020\016\022&\n\"InboundNoRecipientSig" +
-      "natureRequest\020\005\022\'\n#InboundWaitingForReci" +
-      "pientSignature\020\006\022!\n\035InboundWithRecipient" +
-      "Signature\020\007\022,\n(InboundRecipientSignature" +
-      "RequestRejected\020\010\022$\n InboundInvalidRecip" +
-      "ientSignature\020\017\022\'\n#InternalNoRecipientSi" +
-      "gnatureRequest\020\t\022(\n$InternalWaitingForRe" +
-      "cipientSignature\020\n\022\"\n\036InternalWithRecipi" +
-      "entSignature\020\013\022-\n)InternalRecipientSigna" +
-      "tureRequestRejected\020\014\022%\n!InternalWaiting" +
-      "ForSenderSignature\020\020\022\"\n\036InternalInvalidS" +
-      "enderSignature\020\021\022%\n!InternalInvalidRecip" +
-      "ientSignature\020\022B\035B\033NonformalizedDocument" +
-      "Protos"
+      ":\024UnknownReceiptStatus:\002\030\001*\226\006\n\033Nonformal" +
+      "izedDocumentStatus\022&\n\"UnknownNonformaliz" +
+      "edDocumentStatus\020\000\022\'\n#OutboundNoRecipien" +
+      "tSignatureRequest\020\001\022(\n$OutboundWaitingFo" +
+      "rRecipientSignature\020\002\022\"\n\036OutboundWithRec" +
+      "ipientSignature\020\003\022-\n)OutboundRecipientSi" +
+      "gnatureRequestRejected\020\004\022%\n!OutboundWait" +
+      "ingForSenderSignature\020\r\022\"\n\036OutboundInval" +
+      "idSenderSignature\020\016\022&\n\"InboundNoRecipien" +
+      "tSignatureRequest\020\005\022\'\n#InboundWaitingFor" +
+      "RecipientSignature\020\006\022!\n\035InboundWithRecip" +
+      "ientSignature\020\007\022,\n(InboundRecipientSigna" +
+      "tureRequestRejected\020\010\022$\n InboundInvalidR" +
+      "ecipientSignature\020\017\022\'\n#InternalNoRecipie" +
+      "ntSignatureRequest\020\t\022(\n$InternalWaitingF" +
+      "orRecipientSignature\020\n\022\"\n\036InternalWithRe" +
+      "cipientSignature\020\013\022-\n)InternalRecipientS" +
+      "ignatureRequestRejected\020\014\022%\n!InternalWai" +
+      "tingForSenderSignature\020\020\022\"\n\036InternalInva" +
+      "lidSenderSignature\020\021\022%\n!InternalInvalidR" +
+      "ecipientSignature\020\022B\035B\033NonformalizedDocu" +
+      "mentProtos"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/src/main/java/Diadoc/Api/Proto/ExternalServiceAuthInfoProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/ExternalServiceAuthInfoProtos.java
@@ -5,7 +5,7 @@
 
 package Diadoc.Api.Proto;
 
-public final class ExternalServiceAuthInfoProtos {
+@java.lang.Deprecated public final class ExternalServiceAuthInfoProtos {
   private ExternalServiceAuthInfoProtos() {}
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
@@ -25,7 +25,7 @@ public final class ExternalServiceAuthInfoProtos {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
-  public interface ExternalServiceAuthInfoOrBuilder extends
+  @java.lang.Deprecated public interface ExternalServiceAuthInfoOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.ExternalServiceAuthInfo)
       com.google.protobuf.MessageOrBuilder {
 
@@ -66,7 +66,7 @@ public final class ExternalServiceAuthInfoProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.ExternalServiceAuthInfo}
    */
-  public static final class ExternalServiceAuthInfo extends
+  @java.lang.Deprecated public static final class ExternalServiceAuthInfo extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.ExternalServiceAuthInfo)
       ExternalServiceAuthInfoOrBuilder {
@@ -759,9 +759,9 @@ public final class ExternalServiceAuthInfoProtos {
   static {
     java.lang.String[] descriptorData = {
       "\n\035ExternalServiceAuthInfo.proto\022\020Diadoc." +
-      "Api.Proto\"D\n\027ExternalServiceAuthInfo\022\025\n\r" +
-      "ServiceUserId\030\001 \001(\t\022\022\n\nThumbprint\030\002 \001(\tB" +
-      "\037B\035ExternalServiceAuthInfoProtos"
+      "Api.Proto\"H\n\027ExternalServiceAuthInfo\022\025\n\r" +
+      "ServiceUserId\030\001 \001(\t\022\022\n\nThumbprint\030\002 \001(\t:" +
+      "\002\030\001B\"B\035ExternalServiceAuthInfoProtos\270\001\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/src/main/java/Diadoc/Api/Proto/Invoicing/OfficialProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Invoicing/OfficialProtos.java
@@ -5,7 +5,7 @@
 
 package Diadoc.Api.Proto.Invoicing;
 
-public final class OfficialProtos {
+@java.lang.Deprecated public final class OfficialProtos {
   private OfficialProtos() {}
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
@@ -25,7 +25,7 @@ public final class OfficialProtos {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
-  public interface OfficialOrBuilder extends
+  @java.lang.Deprecated public interface OfficialOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Invoicing.Official)
       com.google.protobuf.MessageOrBuilder {
 
@@ -104,7 +104,7 @@ public final class OfficialProtos {
    *
    * Protobuf type {@code Diadoc.Api.Proto.Invoicing.Official}
    */
-  public static final class Official extends
+  @java.lang.Deprecated public static final class Official extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Invoicing.Official)
       OfficialOrBuilder {
@@ -1120,7 +1120,7 @@ public final class OfficialProtos {
 
   }
 
-  public interface AttorneyOrBuilder extends
+  @java.lang.Deprecated public interface AttorneyOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Invoicing.Attorney)
       com.google.protobuf.MessageOrBuilder {
 
@@ -1326,7 +1326,7 @@ public final class OfficialProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Invoicing.Attorney}
    */
-  public static final class Attorney extends
+  @java.lang.Deprecated public static final class Attorney extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Invoicing.Attorney)
       AttorneyOrBuilder {
@@ -3177,16 +3177,16 @@ public final class OfficialProtos {
   static {
     java.lang.String[] descriptorData = {
       "\n\030Invoicing/Official.proto\022\032Diadoc.Api.P" +
-      "roto.Invoicing\"T\n\010Official\022\017\n\007Surname\030\001 " +
+      "roto.Invoicing\"X\n\010Official\022\017\n\007Surname\030\001 " +
       "\002(\t\022\021\n\tFirstName\030\002 \002(\t\022\022\n\nPatronymic\030\003 \001" +
-      "(\t\022\020\n\010JobTitle\030\004 \001(\t\"\202\002\n\010Attorney\022\014\n\004Dat" +
-      "e\030\001 \001(\t\022\016\n\006Number\030\002 \001(\t\022\036\n\026IssuerOrganiz" +
-      "ationName\030\003 \001(\t\022:\n\014IssuerPerson\030\004 \001(\0132$." +
-      "Diadoc.Api.Proto.Invoicing.Official\022\034\n\024I" +
-      "ssuerAdditionalInfo\030\005 \001(\t\022=\n\017RecipientPe" +
-      "rson\030\006 \001(\0132$.Diadoc.Api.Proto.Invoicing." +
-      "Official\022\037\n\027RecipientAdditionalInfo\030\007 \001(" +
-      "\tB\020B\016OfficialProtos"
+      "(\t\022\020\n\010JobTitle\030\004 \001(\t:\002\030\001\"\206\002\n\010Attorney\022\014\n" +
+      "\004Date\030\001 \001(\t\022\016\n\006Number\030\002 \001(\t\022\036\n\026IssuerOrg" +
+      "anizationName\030\003 \001(\t\022:\n\014IssuerPerson\030\004 \001(" +
+      "\0132$.Diadoc.Api.Proto.Invoicing.Official\022" +
+      "\034\n\024IssuerAdditionalInfo\030\005 \001(\t\022=\n\017Recipie" +
+      "ntPerson\030\006 \001(\0132$.Diadoc.Api.Proto.Invoic" +
+      "ing.Official\022\037\n\027RecipientAdditionalInfo\030" +
+      "\007 \001(\t:\002\030\001B\023B\016OfficialProtos\270\001\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/src/main/java/Diadoc/Api/Proto/Invoicing/OrganizationInfoProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Invoicing/OrganizationInfoProtos.java
@@ -5,7 +5,7 @@
 
 package Diadoc.Api.Proto.Invoicing;
 
-public final class OrganizationInfoProtos {
+@java.lang.Deprecated public final class OrganizationInfoProtos {
   private OrganizationInfoProtos() {}
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
@@ -25,7 +25,7 @@ public final class OrganizationInfoProtos {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
-  public interface DocflowParticipantOrBuilder extends
+  @java.lang.Deprecated public interface DocflowParticipantOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Invoicing.DocflowParticipant)
       com.google.protobuf.MessageOrBuilder {
 
@@ -148,7 +148,7 @@ public final class OrganizationInfoProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Invoicing.DocflowParticipant}
    */
-  public static final class DocflowParticipant extends
+  @java.lang.Deprecated public static final class DocflowParticipant extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Invoicing.DocflowParticipant)
       DocflowParticipantOrBuilder {
@@ -1290,7 +1290,7 @@ public final class OrganizationInfoProtos {
 
   }
 
-  public interface DiadocOrganizationInfoOrBuilder extends
+  @java.lang.Deprecated public interface DiadocOrganizationInfoOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Invoicing.DiadocOrganizationInfo)
       com.google.protobuf.MessageOrBuilder {
 
@@ -1353,7 +1353,7 @@ public final class OrganizationInfoProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Invoicing.DiadocOrganizationInfo}
    */
-  public static final class DiadocOrganizationInfo extends
+  @java.lang.Deprecated public static final class DiadocOrganizationInfo extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Invoicing.DiadocOrganizationInfo)
       DiadocOrganizationInfoOrBuilder {
@@ -2156,7 +2156,7 @@ public final class OrganizationInfoProtos {
 
   }
 
-  public interface OrganizationInfoOrBuilder extends
+  @java.lang.Deprecated public interface OrganizationInfoOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Invoicing.OrganizationInfo)
       com.google.protobuf.MessageOrBuilder {
 
@@ -2586,7 +2586,7 @@ public final class OrganizationInfoProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Invoicing.OrganizationInfo}
    */
-  public static final class OrganizationInfo extends
+  @java.lang.Deprecated public static final class OrganizationInfo extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Invoicing.OrganizationInfo)
       OrganizationInfoOrBuilder {
@@ -5889,21 +5889,21 @@ public final class OrganizationInfoProtos {
   static {
     java.lang.String[] descriptorData = {
       "\n Invoicing/OrganizationInfo.proto\022\032Diad" +
-      "oc.Api.Proto.Invoicing\032\rAddress.proto\"W\n" +
+      "oc.Api.Proto.Invoicing\032\rAddress.proto\"[\n" +
       "\022DocflowParticipant\022\r\n\005BoxId\030\001 \001(\t\022\013\n\003In" +
       "n\030\002 \001(\t\022\013\n\003Kpp\030\003 \001(\t\022\030\n\020FnsParticipantId" +
-      "\030\004 \001(\t\"f\n\026DiadocOrganizationInfo\022\r\n\005BoxI" +
-      "d\030\001 \001(\t\022=\n\007OrgInfo\030\002 \001(\0132,.Diadoc.Api.Pr" +
-      "oto.Invoicing.OrganizationInfo\"\271\002\n\020Organ" +
-      "izationInfo\022\014\n\004Name\030\001 \002(\t\022\013\n\003Inn\030\002 \001(\t\022\013" +
-      "\n\003Kpp\030\003 \001(\t\022*\n\007Address\030\004 \002(\0132\031.Diadoc.Ap" +
-      "i.Proto.Address\022\037\n\020IsSoleProprietor\030\005 \001(" +
-      "\010:\005false\022\r\n\005Okopf\030\006 \001(\t\022\014\n\004Okpo\030\007 \001(\t\022\014\n" +
-      "\004Okdp\030\010 \001(\t\022\r\n\005Phone\030\t \001(\t\022\013\n\003Fax\030\n \001(\t\022" +
-      "\031\n\021BankAccountNumber\030\013 \001(\t\022\020\n\010BankName\030\014" +
-      " \001(\t\022\016\n\006BankId\030\r \001(\t\022\022\n\nDepartment\030\016 \001(\t" +
-      "\022\030\n\020FnsParticipantId\030\017 \001(\tB\030B\026Organizati" +
-      "onInfoProtos"
+      "\030\004 \001(\t:\002\030\001\"j\n\026DiadocOrganizationInfo\022\r\n\005" +
+      "BoxId\030\001 \001(\t\022=\n\007OrgInfo\030\002 \001(\0132,.Diadoc.Ap" +
+      "i.Proto.Invoicing.OrganizationInfo:\002\030\001\"\275" +
+      "\002\n\020OrganizationInfo\022\014\n\004Name\030\001 \002(\t\022\013\n\003Inn" +
+      "\030\002 \001(\t\022\013\n\003Kpp\030\003 \001(\t\022*\n\007Address\030\004 \002(\0132\031.D" +
+      "iadoc.Api.Proto.Address\022\037\n\020IsSoleProprie" +
+      "tor\030\005 \001(\010:\005false\022\r\n\005Okopf\030\006 \001(\t\022\014\n\004Okpo\030" +
+      "\007 \001(\t\022\014\n\004Okdp\030\010 \001(\t\022\r\n\005Phone\030\t \001(\t\022\013\n\003Fa" +
+      "x\030\n \001(\t\022\031\n\021BankAccountNumber\030\013 \001(\t\022\020\n\010Ba" +
+      "nkName\030\014 \001(\t\022\016\n\006BankId\030\r \001(\t\022\022\n\nDepartme" +
+      "nt\030\016 \001(\t\022\030\n\020FnsParticipantId\030\017 \001(\t:\002\030\001B\033" +
+      "B\026OrganizationInfoProtos\270\001\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/src/main/java/Diadoc/Api/Proto/Invoicing/Organizations/ExtendedOrganizationInfoProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Invoicing/Organizations/ExtendedOrganizationInfoProtos.java
@@ -180,7 +180,7 @@ public final class ExtendedOrganizationInfoProtos {
     // @@protoc_insertion_point(enum_scope:Diadoc.Api.Proto.Invoicing.Organizations.OrgType)
   }
 
-  public interface ExtendedOrganizationInfoOrBuilder extends
+  @java.lang.Deprecated public interface ExtendedOrganizationInfoOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Invoicing.Organizations.ExtendedOrganizationInfo)
       com.google.protobuf.MessageOrBuilder {
 
@@ -784,7 +784,7 @@ public final class ExtendedOrganizationInfoProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Invoicing.Organizations.ExtendedOrganizationInfo}
    */
-  public static final class ExtendedOrganizationInfo extends
+  @java.lang.Deprecated public static final class ExtendedOrganizationInfo extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Invoicing.Organizations.ExtendedOrganizationInfo)
       ExtendedOrganizationInfoOrBuilder {
@@ -5258,7 +5258,7 @@ public final class ExtendedOrganizationInfoProtos {
     java.lang.String[] descriptorData = {
       "\n(Invoicing/ExtendedOrganizationInfo.pro" +
       "to\022(Diadoc.Api.Proto.Invoicing.Organizat" +
-      "ions\032\rAddress.proto\"\236\004\n\030ExtendedOrganiza" +
+      "ions\032\rAddress.proto\"\242\004\n\030ExtendedOrganiza" +
       "tionInfo\022\r\n\005BoxId\030\001 \001(\t\022\017\n\007OrgName\030\002 \001(\t" +
       "\022\013\n\003Inn\030\003 \001(\t\022\013\n\003Kpp\030\004 \001(\t\022*\n\007Address\030\005 " +
       "\001(\0132\031.Diadoc.Api.Proto.Address\022\030\n\020FnsPar" +
@@ -5272,10 +5272,10 @@ public final class ExtendedOrganizationInfoProtos {
       "tionAdditionalInfo\030\022 \001(\t\022 \n\030Organization" +
       "OrPersonInfo\030\023 \001(\t\022/\n\'IndividualEntityRe" +
       "gistrationCertificate\030\024 \001(\t\022\017\n\007Country\030\025" +
-      " \001(\t*W\n\007OrgType\022\017\n\013LegalEntity\020\001\022\024\n\020Indi" +
-      "vidualEntity\020\002\022\021\n\rForeignEntity\020\003\022\022\n\016Phy" +
-      "sicalEntity\020\004B B\036ExtendedOrganizationInf" +
-      "oProtos"
+      " \001(\t:\002\030\001*W\n\007OrgType\022\017\n\013LegalEntity\020\001\022\024\n\020" +
+      "IndividualEntity\020\002\022\021\n\rForeignEntity\020\003\022\022\n" +
+      "\016PhysicalEntity\020\004B B\036ExtendedOrganizatio" +
+      "nInfoProtos"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/src/main/java/Diadoc/Api/Proto/UserProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/UserProtos.java
@@ -25,7 +25,7 @@ public final class UserProtos {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
-  public interface UserOrBuilder extends
+  @java.lang.Deprecated public interface UserOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.User)
       com.google.protobuf.MessageOrBuilder {
 
@@ -124,7 +124,7 @@ public final class UserProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.User}
    */
-  public static final class User extends
+  @java.lang.Deprecated public static final class User extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.User)
       UserOrBuilder {
@@ -3460,15 +3460,15 @@ public final class UserProtos {
   static {
     java.lang.String[] descriptorData = {
       "\n\nUser.proto\022\020Diadoc.Api.Proto\032\025Certific" +
-      "ateInfo.proto\"\211\001\n\004User\022\n\n\002Id\030\001 \001(\t\022\020\n\010La" +
+      "ateInfo.proto\"\215\001\n\004User\022\n\n\002Id\030\001 \001(\t\022\020\n\010La" +
       "stName\030\002 \001(\t\022\021\n\tFirstName\030\003 \001(\t\022\022\n\nMiddl" +
       "eName\030\004 \001(\t\022<\n\021CloudCertificates\030\005 \003(\0132!" +
-      ".Diadoc.Api.Proto.CertificateInfo\"k\n\006Use" +
-      "rV2\022\016\n\006UserId\030\001 \002(\t\022\r\n\005Login\030\002 \001(\t\022,\n\010Fu" +
-      "llName\030\003 \001(\0132\032.Diadoc.Api.Proto.FullName" +
-      "\022\024\n\014IsRegistered\030\004 \002(\010\"C\n\010FullName\022\020\n\010La" +
-      "stName\030\001 \002(\t\022\021\n\tFirstName\030\002 \002(\t\022\022\n\nMiddl" +
-      "eName\030\003 \001(\tB\014B\nUserProtos"
+      ".Diadoc.Api.Proto.CertificateInfo:\002\030\001\"k\n" +
+      "\006UserV2\022\016\n\006UserId\030\001 \002(\t\022\r\n\005Login\030\002 \001(\t\022," +
+      "\n\010FullName\030\003 \001(\0132\032.Diadoc.Api.Proto.Full" +
+      "Name\022\024\n\014IsRegistered\030\004 \002(\010\"C\n\010FullName\022\020" +
+      "\n\010LastName\030\001 \002(\t\022\021\n\tFirstName\030\002 \002(\t\022\022\n\nM" +
+      "iddleName\030\003 \001(\tB\014B\nUserProtos"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/src/main/java/Diadoc/Api/Proto/Users/UserToUpdateProtos.java
+++ b/src/main/java/Diadoc/Api/Proto/Users/UserToUpdateProtos.java
@@ -25,7 +25,7 @@ public final class UserToUpdateProtos {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
-  public interface UserToUpdateOrBuilder extends
+  @java.lang.Deprecated public interface UserToUpdateOrBuilder extends
       // @@protoc_insertion_point(interface_extends:Diadoc.Api.Proto.Users.UserToUpdate)
       com.google.protobuf.MessageOrBuilder {
 
@@ -62,7 +62,7 @@ public final class UserToUpdateProtos {
   /**
    * Protobuf type {@code Diadoc.Api.Proto.Users.UserToUpdate}
    */
-  public static final class UserToUpdate extends
+  @java.lang.Deprecated public static final class UserToUpdate extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:Diadoc.Api.Proto.Users.UserToUpdate)
       UserToUpdateOrBuilder {
@@ -1954,13 +1954,14 @@ public final class UserToUpdateProtos {
   static {
     java.lang.String[] descriptorData = {
       "\n\030Users/UserToUpdate.proto\022\026Diadoc.Api.P" +
-      "roto.Users\032\nUser.proto\"\202\001\n\014UserToUpdate\022" +
+      "roto.Users\032\nUser.proto\"\206\001\n\014UserToUpdate\022" +
       "5\n\005Login\030\001 \001(\0132&.Diadoc.Api.Proto.Users." +
       "UserLoginPatch\022;\n\010FullName\030\002 \001(\0132).Diado" +
-      "c.Api.Proto.Users.UserFullNamePatch\"\037\n\016U" +
-      "serLoginPatch\022\r\n\005Login\030\001 \001(\t\"A\n\021UserFull" +
-      "NamePatch\022,\n\010FullName\030\001 \001(\0132\032.Diadoc.Api" +
-      ".Proto.FullNameB\024B\022UserToUpdateProtos"
+      "c.Api.Proto.Users.UserFullNamePatch:\002\030\001\"" +
+      "\037\n\016UserLoginPatch\022\r\n\005Login\030\001 \001(\t\"A\n\021User" +
+      "FullNamePatch\022,\n\010FullName\030\001 \001(\0132\032.Diadoc" +
+      ".Api.Proto.FullNameB\024B\022UserToUpdateProto" +
+      "s"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,


### PR DESCRIPTION
Генерация аннотоации Deprecated согласно документации [об устаревших структурах](https://developer.kontur.ru/docs/diadoc-api/index_obsolete.html), а также [удаляемых](https://developer.kontur.ru/docs/diadoc-api/index_removal.html), согласно [политике устаревания](https://developer.kontur.ru/docs/diadoc-api/howtostart/deprecationPolicy.html)