### PR TITLE
Добавление информации о traceId при сценариях с ошибками

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ru.kontur.diadoc</groupId>
     <artifactId>diadocsdk</artifactId>
-    <version>3.27.2</version>
+    <version>3.27.3</version>
 
     <packaging>jar</packaging>
 

--- a/src/main/java/Diadoc/Api/Constants/Headers.java
+++ b/src/main/java/Diadoc/Api/Constants/Headers.java
@@ -1,0 +1,13 @@
+package Diadoc.Api.Constants;
+
+public class Headers {
+    public static String X_DIADOC_ERROR_CODE = "X-Diadoc-ErrorCode";
+
+    public static String X_DIADOC_FILE_NAME = "X-Diadoc-FileName";
+
+    public static String X_SOLUTION_INFO = "X-Solution-Info";
+
+    public static String X_KONTUR_TRACE_ID = "X-Kontur-Trace-Id";
+
+    public static String CONTENT_DISPOSITION = "Content-Disposition";
+}

--- a/src/main/java/Diadoc/Api/document/DocumentClient.java
+++ b/src/main/java/Diadoc/Api/document/DocumentClient.java
@@ -407,12 +407,14 @@ public class DocumentClient {
 
         var response = diadocHttpClient.getResponse(request);
 
+        var traceId = response.getTraceId();
+
         if (response.getRetryAfter() != null) {
-            return new DocumentProtocolResult(response.getRetryAfter());
+            return DocumentProtocolResult.builder().withRetryAfter(response.getRetryAfter()).withTraceId(traceId).build();
         }
         else {
             var documentProtocol = DocumentProtocolProtos.DocumentProtocol.parseFrom(response.getContent());
-            return new DocumentProtocolResult(documentProtocol);
+            return DocumentProtocolResult.builder().withDocumentProtocol(documentProtocol).withTraceId(traceId).build();
         }
     }
 

--- a/src/main/java/Diadoc/Api/exceptions/DiadocException.java
+++ b/src/main/java/Diadoc/Api/exceptions/DiadocException.java
@@ -3,18 +3,25 @@ package Diadoc.Api.exceptions;
 import org.jetbrains.annotations.Nullable;
 
 public class DiadocException extends Exception {
-    private int httpStatusCode;
-    private String errorCode;
+    private final int httpStatusCode;
+    @Nullable
+    private final String errorCode;
+    @Nullable
+    private final String traceId;
 
     public DiadocException(String message, int httpStatusCode, String errorCode) {
-        super(message);
-        this.httpStatusCode = httpStatusCode;
-        this.errorCode = errorCode;
+        this(message, httpStatusCode, errorCode, null);
     }
 
     public DiadocException(String message, int httpStatusCode) {
+        this(message, httpStatusCode, null, null);
+    }
+
+    public DiadocException(String message, int httpStatusCode, @Nullable String errorCode, @Nullable String traceId) {
         super(message);
         this.httpStatusCode = httpStatusCode;
+        this.errorCode = errorCode;
+        this.traceId = traceId;
     }
 
     public int getHttpStatusCode() {
@@ -24,5 +31,10 @@ public class DiadocException extends Exception {
     @Nullable
     public String getErrorCode() {
         return errorCode;
+    }
+
+    @Nullable
+    public String getTraceId() {
+        return traceId;
     }
 }

--- a/src/main/java/Diadoc/Api/exceptions/DiadocSdkException.java
+++ b/src/main/java/Diadoc/Api/exceptions/DiadocSdkException.java
@@ -1,14 +1,35 @@
 package Diadoc.Api.exceptions;
 
 import Diadoc.Api.helpers.System7Emu;
+import org.jetbrains.annotations.Nullable;
 
 public class DiadocSdkException extends Exception {
+    @Nullable
+    private final String traceId;
     public DiadocSdkException(Exception ex) {
         super(ex);
+        this.traceId = extractTraceId(ex);
     }
 
     public DiadocSdkException(String message) {
         super(message);
+        this.traceId = null;
+    }
+
+    @Nullable
+    public String getTraceId() {
+        return traceId;
+    }
+
+    @Nullable
+    private static String extractTraceId(Exception ex) {
+        if (ex instanceof DiadocException) {
+            return ((DiadocException) ex).getTraceId();
+        }
+        if (ex.getCause() instanceof KonturHttpException) {
+            return ((KonturHttpException) ex.getCause()).getTraceId();
+        }
+        return null;
     }
 
     private String formatMessage(Throwable[] exceptions) {

--- a/src/main/java/Diadoc/Api/exceptions/KonturHttpException.java
+++ b/src/main/java/Diadoc/Api/exceptions/KonturHttpException.java
@@ -1,0 +1,33 @@
+package Diadoc.Api.exceptions;
+
+import org.apache.http.client.HttpResponseException;
+import org.jetbrains.annotations.Nullable;
+
+public class KonturHttpException extends HttpResponseException {
+    @Nullable
+    private final String traceId;
+    private final String responseBody;
+
+    public KonturHttpException(int statusCode, String responseBody, @Nullable String traceId) {
+        super(statusCode, buildMessage(statusCode, responseBody, traceId));
+        this.responseBody = responseBody;
+        this.traceId = traceId;
+    }
+
+    private static String buildMessage(int statusCode, String responseBody, String traceId) {
+        return String.format("HTTP %d: %s (TraceId: %s)",
+                statusCode,
+                responseBody != null ? responseBody : "",
+                traceId != null ? traceId : ""
+        );
+    }
+
+    public String getResponseBody() {
+        return responseBody;
+    }
+
+    @Nullable
+    public String getTraceId() {
+        return traceId;
+    }
+}

--- a/src/main/java/Diadoc/Api/helpers/Tools.java
+++ b/src/main/java/Diadoc/Api/helpers/Tools.java
@@ -9,12 +9,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import Diadoc.Api.Constants.Headers;
 import Diadoc.Api.Proto.Forwarding.ForwardedDocumentProtos;
 import com.google.protobuf.ByteString;
+import org.apache.http.HttpResponse;
 import org.apache.http.client.utils.URIBuilder;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
+import org.jetbrains.annotations.Nullable;
 
 public class Tools {
     public static String ConsoleReadLine() throws IOException {
@@ -99,6 +102,12 @@ public class Tools {
         params.add(new BasicNameValuePair("documentId", forwardedDocumentId.getDocumentId().getEntityId()));
         params.add(new BasicNameValuePair("forwardEventId", forwardedDocumentId.getForwardEventId()));
         return params;
+    }
+
+    @Nullable
+    public static String getTraceId(HttpResponse response) {
+        var traceIdHeader = response.getFirstHeader(Headers.X_KONTUR_TRACE_ID);
+        return traceIdHeader != null ? traceIdHeader.getValue() : null;
     }
 
 }

--- a/src/main/java/Diadoc/Api/httpClient/DiadocResponseInfo.java
+++ b/src/main/java/Diadoc/Api/httpClient/DiadocResponseInfo.java
@@ -4,20 +4,23 @@ import org.jetbrains.annotations.Nullable;
 
 public class DiadocResponseInfo {
     @Nullable
-    private byte[] content;
+    private final byte[] content;
     @Nullable
-    private Integer retryAfter;
+    private final Integer retryAfter;
 
-    private int statusCode;
-
-    @Nullable
-    private String reason;
+    private final int statusCode;
 
     @Nullable
-    private String fileName;
+    private final String reason;
 
     @Nullable
-    private String contentType;
+    private final String fileName;
+
+    @Nullable
+    private final String contentType;
+
+    @Nullable
+    private final String traceId;
 
     public DiadocResponseInfo(
             @Nullable byte[] content,
@@ -26,14 +29,76 @@ public class DiadocResponseInfo {
             @Nullable String reason,
             @Nullable String fileName,
             @Nullable String contentType) {
-        this.content = content;
-        this.retryAfter = retryAfter;
-        this.statusCode = statusCode;
-        this.reason = reason;
-        this.fileName = fileName;
-        this.contentType = contentType;
+        this(new DiadocResponseInfoBuilder()
+                .content(content)
+                .retryAfter(retryAfter)
+                .statusCode(statusCode)
+                .reason(reason)
+                .fileName(fileName)
+                .contentType(contentType)
+        );
     }
 
+    public DiadocResponseInfo(DiadocResponseInfoBuilder builder) {
+        this.content = builder.content;
+        this.retryAfter = builder.retryAfter;
+        this.statusCode = builder.statusCode;
+        this.reason = builder.reason;
+        this.fileName = builder.fileName;
+        this.contentType = builder.contentType;
+        this.traceId = builder.traceId;
+    }
+
+    public static class DiadocResponseInfoBuilder {
+        private byte[] content;
+        private Integer retryAfter;
+        private int statusCode;
+        private String reason;
+        private String fileName;
+        private String contentType;
+        private String traceId;
+
+        public DiadocResponseInfoBuilder statusCode(int statusCode) {
+            this.statusCode = statusCode;
+            return this;
+        }
+
+        public DiadocResponseInfoBuilder content(@Nullable byte[] content) {
+            this.content = content;
+            return this;
+        }
+
+        public DiadocResponseInfoBuilder retryAfter(@Nullable Integer retryAfter) {
+            this.retryAfter = retryAfter;
+            return this;
+        }
+
+        public DiadocResponseInfoBuilder reason(@Nullable String reason) {
+            this.reason = reason;
+            return this;
+        }
+
+        public DiadocResponseInfoBuilder fileName(@Nullable String fileName) {
+            this.fileName = fileName;
+            return this;
+        }
+
+        public DiadocResponseInfoBuilder contentType(@Nullable String contentType) {
+            this.contentType = contentType;
+            return this;
+        }
+
+        public DiadocResponseInfoBuilder traceId(@Nullable String traceId) {
+            this.traceId = traceId;
+            return this;
+        }
+
+        public DiadocResponseInfo build() {
+            return new DiadocResponseInfo(this);
+        }
+    }
+    
+    @Nullable
     public String getFileName() {
         return fileName;
     }
@@ -57,8 +122,14 @@ public class DiadocResponseInfo {
         return reason;
     }
 
+    @Nullable
     public String getContentType() {
         return contentType;
+    }
+
+    @Nullable
+    public String getTraceId() {
+        return traceId;
     }
 
     public static DiadocResponseInfo success(byte[] content, int statusCode) {
@@ -69,9 +140,27 @@ public class DiadocResponseInfo {
         return new DiadocResponseInfo(content, null, statusCode, null, fileName, contentType);
     }
 
+    /**
+     * @deprecated Method is deprecated
+     * Use {@link #fail(int, String, Integer, String)}
+     * 
+     */
+    @Deprecated
     public static DiadocResponseInfo fail(int statusCode, String reason, @Nullable Integer retryAfter) {
-        return new DiadocResponseInfo(null, retryAfter, statusCode, reason, null, null);
+        return new DiadocResponseInfo.DiadocResponseInfoBuilder()
+                .statusCode(statusCode)
+                .reason(reason)
+                .retryAfter(retryAfter)
+                .build();
     }
 
+    public static DiadocResponseInfo fail(int statusCode, String reason, @Nullable Integer retryAfter, @Nullable String traceId) {
+        return new DiadocResponseInfo.DiadocResponseInfoBuilder()
+                .statusCode(statusCode)
+                .reason(reason)
+                .retryAfter(retryAfter)
+                .traceId(traceId)
+                .build();
+    }
 
 }

--- a/src/main/java/Diadoc/Api/organizations/OrganizationClient.java
+++ b/src/main/java/Diadoc/Api/organizations/OrganizationClient.java
@@ -379,7 +379,7 @@ public class OrganizationClient {
                 case HttpStatus.SC_FORBIDDEN:
                     return false;
                 default:
-                    throw new DiadocException(response.getReason(), response.getStatusCode());
+                    throw new DiadocException(response.getReason(), response.getStatusCode(), null, response.getTraceId());
             }
         } catch (URISyntaxException | IOException | DiadocException e) {
             throw new DiadocSdkException(e);

--- a/src/main/java/Diadoc/Api/print/PrintFormClient.java
+++ b/src/main/java/Diadoc/Api/print/PrintFormClient.java
@@ -52,10 +52,10 @@ public class PrintFormClient {
             var response = diadocHttpClient.getRawResponse(request);
 
             if (response.getRetryAfter() != null) {
-                return new PrintFormResult(response.getRetryAfter());
+                return new PrintFormResult(response.getRetryAfter(), null, response.getTraceId());
             }
 
-            return new PrintFormResult(new PrintFormContent(response.getContentType(), response.getFileName(), response.getContent()));
+            return new PrintFormResult(0, new PrintFormContent(response.getContentType(), response.getFileName(), response.getContent()), response.getTraceId());
 
         } catch (URISyntaxException | ParseException | IOException e) {
             throw new DiadocSdkException(e);
@@ -154,11 +154,13 @@ public class PrintFormClient {
         var response = executeGeneratePrintFormRequest(fromBoxId, documentType, bytes);
 
         return new PrintFormResult(
+                0,
                 new PrintFormContent(
                         response.getContentType(),
                         response.getFileName() != null ? response.getFileName() : "default",
                         response.getContent()
-                )
+                ),
+                response.getTraceId()
         );
     }
 
@@ -244,11 +246,13 @@ public class PrintFormClient {
 
     private PrintFormResult getPrintFormFromResponse(DiadocResponseInfo response){
         if (response.getRetryAfter() != null) {
-            return new PrintFormResult(response.getRetryAfter());
+            return new PrintFormResult(response.getRetryAfter(), null, response.getTraceId());
         }
         else {
             return new PrintFormResult(
-                    new PrintFormContent(response.getContentType(), response.getFileName(), response.getContent())
+                    0,
+                    new PrintFormContent(response.getContentType(), response.getFileName(), response.getContent()),
+                    response.getTraceId()
             );
         }
     }

--- a/src/main/java/Diadoc/Api/print/models/DocumentProtocolResult.java
+++ b/src/main/java/Diadoc/Api/print/models/DocumentProtocolResult.java
@@ -1,23 +1,74 @@
 package Diadoc.Api.print.models;
 
 import Diadoc.Api.Proto.Documents.DocumentProtocolProtos;
+import org.jetbrains.annotations.Nullable;
 
 public class DocumentProtocolResult {
-    private int retryAfter;
-    private DocumentProtocolProtos.DocumentProtocol documentProtocol;
+    private final int retryAfter;
+
+    @Nullable
+    private final DocumentProtocolProtos.DocumentProtocol documentProtocol;
+
+    @Nullable
+    private final String traceId;
 
     public DocumentProtocolResult(DocumentProtocolProtos.DocumentProtocol documentProtocol)
     {
         this.documentProtocol = documentProtocol;
         this.retryAfter = 0;
+        this.traceId = null;
     }
 
     public DocumentProtocolResult(int retryAfter)
     {
+        this.documentProtocol = null;
         this.retryAfter = retryAfter;
+        this.traceId = null;
+    }
+
+    private DocumentProtocolResult(DocumentProtocolResultBuilder builder) {
+        this.documentProtocol = builder.documentProtocol;
+        this.retryAfter = builder.retryAfter;
+        this.traceId = builder.traceId;
+    }
+
+    public static class DocumentProtocolResultBuilder {
+        private DocumentProtocolProtos.DocumentProtocol documentProtocol;
+        private int retryAfter = 0;
+        private String traceId;
+
+        public DocumentProtocolResultBuilder withDocumentProtocol(DocumentProtocolProtos.DocumentProtocol documentProtocol) {
+            this.documentProtocol = documentProtocol;
+            return this;
+        }
+
+        public DocumentProtocolResultBuilder withRetryAfter(int retryAfter) {
+            this.retryAfter = retryAfter;
+            return this;
+        }
+
+        public DocumentProtocolResultBuilder withTraceId(String traceId) {
+            this.traceId = traceId;
+            return this;
+        }
+
+        public DocumentProtocolResult build() {
+            return new DocumentProtocolResult(this);
+        }
+    }
+
+    public static DocumentProtocolResultBuilder builder() {
+        return new DocumentProtocolResultBuilder();
     }
 
     public boolean hasContent() { return documentProtocol != null; }
+    @Nullable
     public DocumentProtocolProtos.DocumentProtocol getDocumentProtocol() { return documentProtocol; }
+
+    @Nullable
+    public String getTraceId() {
+        return traceId;
+    }
+
     public int getRetryAfter() { return retryAfter; }
 }

--- a/src/main/java/Diadoc/Api/print/models/PrintFormResult.java
+++ b/src/main/java/Diadoc/Api/print/models/PrintFormResult.java
@@ -1,16 +1,27 @@
 package Diadoc.Api.print.models;
 
+import org.jetbrains.annotations.Nullable;
+
 public class PrintFormResult {
-    private int retryAfter;
-    private PrintFormContent content;
+    private final int retryAfter;
+    @Nullable
+    private final PrintFormContent content;
+
+    @Nullable
+    private final String traceId;
 
     public PrintFormResult(PrintFormContent content) {
-        this.content = content;
-        this.retryAfter = 0;
+        this(0, content, null);
     }
 
     public PrintFormResult(int retryAfter) {
+        this(retryAfter, null, null);
+    }
+
+    public PrintFormResult(int retryAfter, @Nullable PrintFormContent content, @Nullable String traceId) {
         this.retryAfter = retryAfter;
+        this.content = content;
+        this.traceId = traceId;
     }
 
     public boolean HasContent() {
@@ -23,5 +34,10 @@ public class PrintFormResult {
 
     public int getRetryAfter() {
         return retryAfter;
+    }
+
+    @Nullable
+    public String getTraceId() {
+        return traceId;
     }
 }

--- a/src/main/java/Diadoc/Api/shelf/ShelfClient.java
+++ b/src/main/java/Diadoc/Api/shelf/ShelfClient.java
@@ -17,6 +17,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static Diadoc.Api.helpers.Tools.getTraceId;
+
 public class ShelfClient {
     private DiadocHttpClient diadocHttpClient;
 
@@ -125,12 +127,13 @@ public class ShelfClient {
         {
             try {
                 var response = diadocHttpClient.getResponse(RequestBuilder.post(url.build()).setEntity(new ByteArrayEntity(content)));
+                var traceId = response.getTraceId();
                 if (response.getStatusCode() != HttpStatus.SC_OK) {
                     if (SHELF_NON_RETRIABLE_STATUS_CODES.contains(response.getStatusCode())) {
-                        throw new DiadocException(formatResponseMessage(response.getReason(), response.getStatusCode()), response.getStatusCode());
+                        throw new DiadocException(formatResponseMessage(response.getReason(), response.getStatusCode(), traceId), response.getStatusCode(), null, traceId);
                     }
 
-                    httpErrors.add(new DiadocException(formatResponseMessage(response.getReason(), response.getStatusCode()), response.getStatusCode()));
+                    httpErrors.add(new DiadocException(formatResponseMessage(response.getReason(), response.getStatusCode(), traceId), response.getStatusCode(), null, traceId));
                 }
 
                 responseContent = response.getContent();
@@ -206,11 +209,12 @@ public class ShelfClient {
         {
             var response = diadocHttpClient.getResponse(RequestBuilder.post(url.build()).setEntity(new ByteArrayEntity(firstPart.getBytes())));
             if (response.getStatusCode() != HttpStatus.SC_OK) {
+                var traceId = response.getTraceId();
                 if (SHELF_NON_RETRIABLE_STATUS_CODES.contains(response.getStatusCode())) {
-                    throw new DiadocException(formatResponseMessage(response.getReason(), response.getStatusCode()), response.getStatusCode());
+                    throw new DiadocException(formatResponseMessage(response.getReason(), response.getStatusCode(), traceId), response.getStatusCode(), null, traceId);
                 }
 
-                httpErrors.add(new DiadocException(formatResponseMessage(response.getReason(), response.getStatusCode()), response.getStatusCode()));
+                httpErrors.add(new DiadocException(formatResponseMessage(response.getReason(), response.getStatusCode(), traceId), response.getStatusCode(), null, traceId));
             }
 
             var responseContent = response.getContent();
@@ -269,11 +273,12 @@ public class ShelfClient {
         try {
             var response = diadocHttpClient.getResponse(RequestBuilder.post(url.build()).setEntity(new ByteArrayEntity(part.getBytes())));
             if (response.getStatusCode() != HttpStatus.SC_OK) {
+                var traceId = response.getTraceId();
                 if (SHELF_NON_RETRIABLE_STATUS_CODES.contains(response.getStatusCode())) {
-                    throw new DiadocException(formatResponseMessage(response.getReason(), response.getStatusCode()), response.getStatusCode());
+                    throw new DiadocException(formatResponseMessage(response.getReason(), response.getStatusCode(), traceId), response.getStatusCode(), null, traceId);
                 }
 
-                httpErrors.add(new DiadocException(formatResponseMessage(response.getReason(), response.getStatusCode()), response.getStatusCode()));
+                httpErrors.add(new DiadocException(formatResponseMessage(response.getReason(), response.getStatusCode(), traceId), response.getStatusCode(), null, traceId));
                 return null;
             }
 
@@ -339,11 +344,12 @@ public class ShelfClient {
         try {
             var response = diadocHttpClient.getResponse(RequestBuilder.post(url.build()).setEntity(new ByteArrayEntity(part.getBytes())));
             if (response.getStatusCode() != HttpStatus.SC_OK) {
+                var traceId = response.getTraceId();
                 if (SHELF_NON_RETRIABLE_STATUS_CODES.contains(response.getStatusCode())) {
-                    throw new DiadocException(formatResponseMessage(response.getReason(), response.getStatusCode()), response.getStatusCode());
+                    throw new DiadocException(formatResponseMessage(response.getReason(), response.getStatusCode(), traceId), response.getStatusCode(), null, traceId);
                 }
 
-                httpErrors.add(new DiadocException(formatResponseMessage(response.getReason(), response.getStatusCode()), response.getStatusCode()));
+                httpErrors.add(new DiadocException(formatResponseMessage(response.getReason(), response.getStatusCode(), traceId), response.getStatusCode(), null, traceId));
                 return null;
             }
 
@@ -374,12 +380,11 @@ public class ShelfClient {
         return result;
     }
 
-    private String formatResponseMessage(String reason, int statusCode) {
-        return String.format("Status code:%s%sMessage:%s%s",
-                statusCode,
-                System7Emu.lineSeparator(),
-                reason,
-                System7Emu.lineSeparator());
+    private String formatResponseMessage(String reason, int statusCode, String traceId) {
+        return String.format("Status code:%s%sMessage:%s%sTraceId: %s%s",
+                statusCode, System7Emu.lineSeparator(),
+                reason, System7Emu.lineSeparator(),
+                traceId, System7Emu.lineSeparator());
     }
 
     private String formatHttpErrors(List<Exception> errors) {


### PR DESCRIPTION
Суть решения: прокинуть в исключения клиентов DiadocException и DiadocSdkException вложенное исключение с информацией о traceId, это позволит не сломать обратную совместимость и получить дешево вывод с ошибкой в стек трейсе, а также в случаях возвращения класса результата с ошибкой добавить туда информацию о traceId и возможность ее вытащить.